### PR TITLE
Change dev dependencies name inline with project template

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,10 @@ $ git clone https://github.com/astronomy-commons/hipscat-import
 $ cd hipscat-import
 $ pip install -e .
 ```
+
+### Installing dev dependencies on Mac
+
+```bash
+$ pip install '.[dev]'
+```
+(Make sure to include the single quotes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)
 [project.optional-dependencies]
-test = [
+dev = [
     "pytest", 
     "pytest-cov",
 ]


### PR DESCRIPTION
Change the name of the dev dependencies to match the project templates and other projects, similar to astronomy-commons/hipscat#13.

Also updated the README to include instructions for installing with dev dependencies on Mac.