### PR TITLE
Improve progress reporting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "hipscat",
     "pandas",
     "pyarrow",
+    "tqdm",
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)

--- a/src/hipscat_import/run_import.py
+++ b/src/hipscat_import/run_import.py
@@ -3,7 +3,8 @@
 import hipscat.io.write_metadata as io
 import hipscat.pixel_math as pixel_math
 import numpy as np
-from dask.distributed import Client, progress, wait
+from dask.distributed import Client, as_completed
+from tqdm import tqdm
 
 import hipscat_import.map_reduce as mr
 from hipscat_import.arguments import ImportArguments
@@ -27,14 +28,15 @@ def _map_pixels(args, client):
                 cache_path=None if args.debug_stats_only else args.tmp_dir,
             )
         )
-    if args.progress_bar:
-        progress(futures)
-    else:
-        wait(futures)
 
     raw_histogram = pixel_math.empty_histogram(args.highest_healpix_order)
-    for future in futures:
-        raw_histogram = np.add(raw_histogram, future.result())
+    for _, result in tqdm(
+        as_completed(futures, with_results=True),
+        desc="Mapping  ",
+        total=len(futures),
+        disable=(not args.progress_bar),
+    ):
+        raw_histogram = np.add(raw_histogram, result)
     return raw_histogram
 
 
@@ -55,10 +57,13 @@ def _reduce_pixels(args, destination_pixel_map, client):
                 id_column=args.id_column,
             )
         )
-    if args.progress_bar:
-        progress(futures)
-    else:
-        wait(futures)
+    for _ in tqdm(
+        as_completed(futures),
+        desc="Reducing ",
+        total=len(futures),
+        disable=(not args.progress_bar),
+    ):
+        pass
 
 
 def _validate_args(args):
@@ -84,16 +89,27 @@ def run_with_client(args, client):
     """Importer, where the client context may out-live the runner"""
     _validate_args(args)
     raw_histogram = _map_pixels(args, client)
+
+    step_progress = tqdm(total=2, desc="Binning  ", disable=(not args.progress_bar))
     pixel_map = pixel_math.generate_alignment(
         raw_histogram, args.highest_healpix_order, args.pixel_threshold
     )
+    step_progress.update(1)
     destination_pixel_map = pixel_math.generate_destination_pixel_map(
         raw_histogram, pixel_map
     )
+    step_progress.update(1)
+    step_progress.close()
+
     if not args.debug_stats_only:
         _reduce_pixels(args, destination_pixel_map, client)
 
     # All done - write out the metadata
+    step_progress = tqdm(total=3, desc="Finishing", disable=(not args.progress_bar))
     io.write_legacy_metadata(args, raw_histogram, pixel_map)
+    step_progress.update(1)
     io.write_catalog_info(args, raw_histogram)
+    step_progress.update(1)
     io.write_partition_info(args, destination_pixel_map)
+    step_progress.update(1)
+    step_progress.close()


### PR DESCRIPTION
Use tqdm for cleaner command line progress bar. Adds a progress bar for non-parallelized process steps, to make the user feel like something's happening.