### PR TITLE
Add console entry points for import tool.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,5 +54,9 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 write_to = "src/hipscat_import/_version.py"
 
+[project.scripts]
+hipscat-import = "hipscat_import.control:main"
+hc = "hipscat_import.control:main"
+
 [tool.pytest.ini_options]
 timeout = 1

--- a/src/hipscat_import/__init__.py
+++ b/src/hipscat_import/__init__.py
@@ -2,6 +2,7 @@
 
 from .arguments import ImportArguments
 from .command_line_arguments import parse_command_line
+from .control import main
 from .file_readers import (
     CsvReader,
     FitsReader,

--- a/src/hipscat_import/__main__.py
+++ b/src/hipscat_import/__main__.py
@@ -1,9 +1,7 @@
 """Main method to enable command line execution"""
 
-import sys
 
-import hipscat_import.run_import as runner
-from hipscat_import.command_line_arguments import parse_command_line
+from hipscat_import.control import main
 
 if __name__ == "__main__":
-    runner.run(parse_command_line(sys.argv[1:]))
+    main()

--- a/src/hipscat_import/command_line_arguments.py
+++ b/src/hipscat_import/command_line_arguments.py
@@ -21,7 +21,6 @@ def parse_command_line(cl_args):
         "--catalog_name",
         help="short name for the catalog that will be used for the output directory",
         default=None,
-        required=True,
         type=str,
     )
     group.add_argument(
@@ -113,7 +112,6 @@ def parse_command_line(cl_args):
         "--output_path",
         help="path prefix for partitioned output and metadata files",
         default=None,
-        required=True,
         type=str,
     )
     group.add_argument(

--- a/src/hipscat_import/command_line_arguments.py
+++ b/src/hipscat_import/command_line_arguments.py
@@ -21,6 +21,7 @@ def parse_command_line(cl_args):
         "--catalog_name",
         help="short name for the catalog that will be used for the output directory",
         default=None,
+        required=True,
         type=str,
     )
     group.add_argument(
@@ -112,6 +113,7 @@ def parse_command_line(cl_args):
         "--output_path",
         help="path prefix for partitioned output and metadata files",
         default=None,
+        required=True,
         type=str,
     )
     group.add_argument(

--- a/src/hipscat_import/control.py
+++ b/src/hipscat_import/control.py
@@ -1,0 +1,10 @@
+"""Flow control and scripting entry points."""
+import sys
+
+import hipscat_import.run_import as runner
+from hipscat_import.command_line_arguments import parse_command_line
+
+
+def main():
+    """Wrapper of main for setuptools."""
+    runner.run(parse_command_line(sys.argv[1:]))


### PR DESCRIPTION
With this, you can execute the import tool with commands like:

```
> hipscat-import --help
or
> hc --help
```