### PR TITLE
Prefactor for alternate table import arguments.

### DIFF
--- a/src/.pylintrc
+++ b/src/.pylintrc
@@ -286,7 +286,7 @@ max-attributes=7
 max-bool-expr=5
 
 # Maximum number of branch for function / method body.
-max-branches=12
+max-branches=15
 
 # Maximum number of locals for function / method body.
 max-locals=15

--- a/src/hipscat_import/__init__.py
+++ b/src/hipscat_import/__init__.py
@@ -1,3 +1,4 @@
 """All modules for hipscat-import package"""
 
 from .control import main
+from .runtime_arguments import RuntimeArguments

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -96,7 +96,8 @@ class ImportArguments(RuntimeArguments):
 
         if not 0 <= self.highest_healpix_order <= hipscat_id.HIPSCAT_ID_HEALPIX_ORDER:
             raise ValueError(
-                f"highest_healpix_order should be between 0 and {hipscat_id.HIPSCAT_ID_HEALPIX_ORDER}"
+                "highest_healpix_order should be between 0 and "
+                f"{hipscat_id.HIPSCAT_ID_HEALPIX_ORDER}"
             )
         if not 100 <= self.pixel_threshold <= 10_000_000:
             raise ValueError("pixel_threshold should be between 100 and 10,000,000")

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -73,13 +73,13 @@ class ImportArguments(RuntimeArguments):
     dec_column: str = "dec"
     id_column: str = "id"
     add_hipscat_index: bool = True
-    use_schema_file: str = None
+    use_schema_file: str | None = None
     resume: bool = False
     highest_healpix_order: int = 10
     pixel_threshold: int = 1_000_000
     debug_stats_only: bool = False
-    filter_function: Callable = None
-    file_reader: InputReader = None
+    filter_function: Callable | None = None
+    file_reader: InputReader | None = None
 
     def __post_init__(self):
         RuntimeArguments._check_arguments(self)

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -1,17 +1,20 @@
 """Utility to hold all arguments required throughout partitioning"""
 
-from importlib.metadata import version
+from dataclasses import dataclass, field
+from typing import Callable
 
 import pandas as pd
 from hipscat.catalog import CatalogParameters
 from hipscat.io import file_io
 
-from hipscat_import.catalog.file_readers import get_file_reader
+from hipscat_import.catalog.file_readers import InputReader, get_file_reader
+from hipscat_import.runtime_arguments import RuntimeArguments
 
 # pylint: disable=too-many-locals,too-many-arguments,too-many-instance-attributes,too-many-branches,too-few-public-methods
 
 
-class ImportArguments:
+@dataclass
+class ImportArguments(RuntimeArguments):
     """Container class for holding partitioning arguments
 
 
@@ -58,156 +61,78 @@ class ImportArguments:
         dask_threads_per_worker (int): number of threads per dask worker.
     """
 
-    def __init__(
-        self,
-        catalog_name="",
-        epoch="J2000",
-        catalog_type="object",
-        input_path="",
-        input_format="parquet",
-        input_file_list=None,
-        ra_column="ra",
-        dec_column="dec",
-        id_column="id",
-        add_hipscat_index=True,
-        use_schema_file=None,
-        output_path="",
-        overwrite=False,
-        resume=False,
-        highest_healpix_order=10,
-        pixel_threshold=1_000_000,
-        debug_stats_only=False,
-        filter_function=None,
-        file_reader=None,
-        tmp_dir="",
-        progress_bar=True,
-        dask_tmp="",
-        dask_n_workers=1,
-        dask_threads_per_worker=1,
-    ):
-        self.catalog_name = catalog_name
-        self.epoch = epoch
-        self.catalog_type = catalog_type
-        self._input_path = file_io.get_file_pointer_from_path(input_path)
-        self.input_format = input_format
-        self._input_file_list = (
-            [file_io.get_file_pointer_from_path(x) for x in input_file_list]
-            if input_file_list
+    epoch: str = "J2000"
+    catalog_type: str = "object"
+    input_path: str = ""
+    input_format: str = ""
+    input_file_list: list[str] = field(default_factory=list)
+
+    ra_column: str = "ra"
+    dec_column: str = "dec"
+    id_column: str = "id"
+    add_hipscat_index: bool = True
+    use_schema_file: str = None
+    resume: bool = False
+    highest_healpix_order: int = 10
+    pixel_threshold: int = 1_000_000
+    debug_stats_only: bool = False
+    filter_function: Callable = None
+    file_reader: InputReader = None
+
+    def __post_init__(self):
+        RuntimeArguments._check_arguments(self)
+        self.input_path = file_io.get_file_pointer_from_path(self.input_path)
+        self.input_file_list = (
+            [file_io.get_file_pointer_from_path(x) for x in self.input_file_list]
+            if self.input_file_list
             else None
         )
         self.input_paths = []
 
-        self.ra_column = ra_column
-        self.dec_column = dec_column
-        self.id_column = id_column
-        self.add_hipscat_index = add_hipscat_index
-        self.use_schema_file = use_schema_file
-
-        self._output_path = file_io.get_file_pointer_from_path(output_path)
-        self.overwrite = overwrite
-        self.resume = resume
-        self.highest_healpix_order = highest_healpix_order
-        self.pixel_threshold = pixel_threshold
-        self.debug_stats_only = debug_stats_only
-        self.catalog_path = ""
-        self.tmp_path = ""
-
-        self.filter_function = (
-            filter_function if filter_function else passthrough_filter_function
-        )
-        self.file_reader = file_reader
-
-        self._tmp_dir = file_io.get_file_pointer_from_path(tmp_dir)
-        self.progress_bar = progress_bar
-        self.dask_tmp = file_io.get_file_pointer_from_path(dask_tmp)
-        self.dask_n_workers = dask_n_workers
-        self.dask_threads_per_worker = dask_threads_per_worker
+        if not self.filter_function:
+            self.filter_function = passthrough_filter_function
 
         self._check_arguments()
-        self._check_paths()
 
     def _check_arguments(self):
         """Check existence and consistency of argument values"""
-        if not self.catalog_name:
-            raise ValueError("catalog_name is required")
         if not self.input_format:
             raise ValueError("input_format is required")
-        if not self._output_path:
-            raise ValueError("output_path is required")
 
         if not 0 <= self.highest_healpix_order <= 19:
             raise ValueError("highest_healpix_order should be between 0 and 19")
         if not 100 <= self.pixel_threshold <= 10_000_000:
             raise ValueError("pixel_threshold should be between 100 and 10,000,000")
 
-        if self.dask_n_workers <= 0:
-            raise ValueError("dask_n_workers should be greather than 0")
-        if self.dask_threads_per_worker <= 0:
-            raise ValueError("dask_threads_per_worker should be greather than 0")
-
         if self.catalog_type not in ("source", "object"):
             raise ValueError("catalog_type should be one of `source` or `object`")
 
+        if (not self.input_path and not self.input_file_list) or (
+            self.input_path and self.input_file_list
+        ):
+            raise ValueError("exactly one of input_path or input_file_list is required")
         if not self.file_reader:
             self.file_reader = get_file_reader(self.input_format)
 
-    def _check_paths(self):
-        """Check existence and permissions on provided path arguments"""
-        if (not self._input_path and not self._input_file_list) or (
-            self._input_path and self._input_file_list
-        ):
-            raise ValueError("exactly one of input_path or input_file_list is required")
-
-        if not file_io.does_file_or_directory_exist(self._output_path):
-            raise FileNotFoundError(
-                f"output_path ({self._output_path}) not found on local storage"
-            )
-
-        # Catalog path should not already exist, unless we're overwriting. Create it.
-        self.catalog_path = file_io.append_paths_to_pointer(
-            self._output_path, self.catalog_name
-        )
-        if not self.overwrite:
-            if file_io.directory_has_contents(self.catalog_path):
-                raise ValueError(
-                    f"output_path ({self.catalog_path}) contains files."
-                    " choose a different directory or use --overwrite flag"
-                )
-        file_io.make_directory(self.catalog_path, exist_ok=True)
-
         # Basic checks complete - make more checks and create directories where necessary
-        if self._input_path:
-            if not file_io.does_file_or_directory_exist(self._input_path):
+        if self.input_path:
+            if not file_io.does_file_or_directory_exist(self.input_path):
                 raise FileNotFoundError("input_path not found on local storage")
             self.input_paths = file_io.find_files_matching_path(
-                self._input_path, f"*{self.input_format}"
+                self.input_path, f"*{self.input_format}"
             )
 
             if len(self.input_paths) == 0:
                 raise FileNotFoundError(
-                    f"No files matched file pattern: {self._input_path}*{self.input_format} "
+                    f"No files matched file pattern: {self.input_path}*{self.input_format} "
                 )
-        elif self._input_file_list:
-            self.input_paths = self._input_file_list
+        elif self.input_file_list:
+            self.input_paths = self.input_file_list
             for test_path in self.input_paths:
                 if not file_io.does_file_or_directory_exist(test_path):
                     raise FileNotFoundError(f"{test_path} not found on local storage")
-        if not self.input_paths:
-            raise FileNotFoundError("No input files found")
         self.input_paths.sort()
 
-        if self._tmp_dir:
-            self.tmp_path = file_io.append_paths_to_pointer(
-                self._tmp_dir, self.catalog_name, "intermediate"
-            )
-        elif self.dask_tmp:
-            self.tmp_path = file_io.append_paths_to_pointer(
-                self.dask_tmp, self.catalog_name, "intermediate"
-            )
-        else:
-            self.tmp_path = file_io.append_paths_to_pointer(
-                self.catalog_path, "intermediate"
-            )
         if not self.resume:
             if file_io.directory_has_contents(self.tmp_path):
                 raise ValueError(
@@ -223,79 +148,31 @@ class ImportArguments:
             CatalogParameters for catalog being created.
         """
         return CatalogParameters(
-            catalog_name=self.catalog_name,
+            catalog_name=self.output_catalog_name,
             catalog_type=self.catalog_type,
-            output_path=self._output_path,
+            output_path=self.output_path,
             epoch=self.epoch,
             ra_column=self.ra_column,
             dec_column=self.dec_column,
         )
 
-    def provenance_info(self) -> dict:
-        """Fill all known information in a dictionary for provenance tracking.
-
-        Returns:
-            dictionary with all argument_name -> argument_value as key -> value pairs.
-        """
-        runtime_args = {
-            "catalog_name": self.catalog_name,
+    def additional_provenance_info(self):
+        return {
+            "catalog_name": self.output_catalog_name,
             "epoch": self.epoch,
             "catalog_type": self.catalog_type,
-            "input_path": str(self._input_path),
+            "input_path": str(self.input_path),
             "input_paths": self.input_paths,
             "input_format": self.input_format,
-            "input_file_list": self._input_file_list,
+            "input_file_list": self.input_file_list,
             "ra_column": self.ra_column,
             "dec_column": self.dec_column,
             "id_column": self.id_column,
-            "output_path": str(self._output_path),
-            "overwrite": self.overwrite,
-            "resume": self.resume,
-            "use_schema_file": self.use_schema_file,
             "highest_healpix_order": self.highest_healpix_order,
             "pixel_threshold": self.pixel_threshold,
             "debug_stats_only": self.debug_stats_only,
-            "catalog_path": self.catalog_path,
-            "tmp_path": str(self.tmp_path),
-            "progress_bar": self.progress_bar,
-            "dask_tmp": str(self.dask_tmp),
-            "dask_n_workers": self.dask_n_workers,
-            "dask_threads_per_worker": self.dask_threads_per_worker,
             "file_reader_info": self.file_reader.provenance_info(),
         }
-        runtime_args["uses_filter_function"] = (
-            self.filter_function != passthrough_filter_function
-        )
-        provenance_info = {
-            "tool_name": "hipscat_import",
-            "version": version("hipscat-import"),
-            "runtime_args": runtime_args,
-        }
-
-        return provenance_info
-
-    def __str__(self):
-        formatted_string = (
-            f"  catalog_name {self.catalog_name}\n"
-            f"  catalog_type {self.catalog_type}\n"
-            f"  input_path {self._input_path}\n"
-            f"  input format {self.input_format}\n"
-            f"  num input_paths {len(self.input_paths)}\n"
-            f"  ra_column {self.ra_column}\n"
-            f"  dec_column {self.dec_column}\n"
-            f"  id_column {self.id_column}\n"
-            f"  output_path {self._output_path}\n"
-            f"  overwrite {self.overwrite}\n"
-            f"  highest_healpix_order {self.highest_healpix_order}\n"
-            f"  pixel_threshold {self.pixel_threshold}\n"
-            f"  debug_stats_only {self.debug_stats_only}\n"
-            f"  progress_bar {self.progress_bar}\n"
-            f"  dask_tmp {self.dask_tmp}\n"
-            f"  dask_n_workers {self.dask_n_workers}\n"
-            f"  dask_threads_per_worker {self.dask_threads_per_worker}\n"
-            f"  tmp_path {self.tmp_path}\n"
-        )
-        return formatted_string
 
 
 def passthrough_filter_function(data: pd.DataFrame) -> pd.DataFrame:

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -1,7 +1,7 @@
 """Utility to hold all arguments required throughout partitioning"""
 
 from dataclasses import dataclass, field
-from typing import Callable
+from typing import Callable, List
 
 import pandas as pd
 from hipscat.catalog import CatalogParameters
@@ -65,7 +65,7 @@ class ImportArguments(RuntimeArguments):
     catalog_type: str = "object"
     input_path: str = ""
     input_format: str = ""
-    input_file_list: list[str] = field(default_factory=list)
+    input_file_list: List[str] = field(default_factory=List)
 
     ra_column: str = "ra"
     dec_column: str = "dec"

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -1,5 +1,7 @@
 """Utility to hold all arguments required throughout partitioning"""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Callable, List
 
@@ -65,7 +67,7 @@ class ImportArguments(RuntimeArguments):
     catalog_type: str = "object"
     input_path: str = ""
     input_format: str = ""
-    input_file_list: List[str] = field(default_factory=List)
+    input_file_list: List[str] = field(default_factory=list)
 
     ra_column: str = "ra"
     dec_column: str = "dec"

--- a/src/hipscat_import/catalog/command_line_arguments.py
+++ b/src/hipscat_import/catalog/command_line_arguments.py
@@ -215,7 +215,7 @@ def parse_command_line(cl_args):
     args = parser.parse_args(cl_args)
 
     return ImportArguments(
-        catalog_name=args.catalog_name,
+        output_catalog_name=args.catalog_name,
         input_path=args.input_path,
         input_format=args.input_format,
         input_file_list=(

--- a/src/hipscat_import/runtime_arguments.py
+++ b/src/hipscat_import/runtime_arguments.py
@@ -101,7 +101,7 @@ class RuntimeArguments:
             "tmp_path": str(self.tmp_path),
         }
 
-        runtime_args.update(self.additional_provenance_info())
+        runtime_args.update(self.additional_runtime_provenance_info())
         provenance_info = {
             "tool_name": "hipscat_import",
             "version": version("hipscat-import"),
@@ -110,6 +110,6 @@ class RuntimeArguments:
 
         return provenance_info
 
-    def additional_provenance_info(self):
-        """Any additional provenance info from subclasses"""
+    def additional_runtime_provenance_info(self):
+        """Any additional runtime args to be included in provenance info from subclasses"""
         return {}

--- a/src/hipscat_import/runtime_arguments.py
+++ b/src/hipscat_import/runtime_arguments.py
@@ -1,0 +1,115 @@
+"""Data class to hold common runtime arguments for dataset creation."""
+
+import re
+from dataclasses import dataclass
+from importlib.metadata import version
+
+from hipscat.io import file_io
+
+# pylint: disable=too-many-instance-attributes
+
+
+@dataclass
+class RuntimeArguments:
+    """Data class for holding runtime arguments"""
+
+    ## Output
+    output_path: str = ""
+    output_catalog_name: str = ""
+
+    ## Execution
+    tmp_dir: str = ""
+    overwrite: bool = False
+    progress_bar: bool = True
+    dask_tmp: str = ""
+    dask_n_workers: int = 1
+    dask_threads_per_worker: int = 1
+
+    catalog_path = ""
+    tmp_path = ""
+
+    def __post_init__(self):
+        self._check_arguments()
+
+    def _check_arguments(self):
+        if not self.output_path:
+            raise ValueError("output_path is required")
+        if not self.output_catalog_name:
+            raise ValueError("output_catalog_name is required")
+        if re.search(r"[^A-Za-z0-9_\-\\]", self.output_catalog_name):
+            raise ValueError("output_catalog_name contains invalid characters")
+
+        if self.dask_n_workers <= 0:
+            raise ValueError("dask_n_workers should be greather than 0")
+        if self.dask_threads_per_worker <= 0:
+            raise ValueError("dask_threads_per_worker should be greater than 0")
+
+        if not file_io.does_file_or_directory_exist(self.output_path):
+            raise FileNotFoundError(
+                f"output_path ({self.output_path}) not found on local storage"
+            )
+
+        self.catalog_path = file_io.append_paths_to_pointer(
+            self.output_path, self.output_catalog_name
+        )
+        if not self.overwrite:
+            if file_io.directory_has_contents(self.catalog_path):
+                raise ValueError(
+                    f"output_path ({self.catalog_path}) contains files."
+                    " choose a different directory or use --overwrite flag"
+                )
+        file_io.make_directory(self.catalog_path, exist_ok=True)
+
+        if self.tmp_dir:
+            if not file_io.does_file_or_directory_exist(self.tmp_dir):
+                raise FileNotFoundError(
+                    f"tmp_dir ({self.tmp_dir}) not found on local storage"
+                )
+            self.tmp_path = file_io.append_paths_to_pointer(
+                self.tmp_dir, self.output_catalog_name, "intermediate"
+            )
+        elif self.dask_tmp:
+            if not file_io.does_file_or_directory_exist(self.dask_tmp):
+                raise FileNotFoundError(
+                    f"dask_tmp ({self.dask_tmp}) not found on local storage"
+                )
+            self.tmp_path = file_io.append_paths_to_pointer(
+                self.dask_tmp, self.output_catalog_name, "intermediate"
+            )
+        else:
+            self.tmp_path = file_io.append_paths_to_pointer(
+                self.catalog_path, "intermediate"
+            )
+        file_io.make_directory(self.tmp_path, exist_ok=True)
+
+    def provenance_info(self) -> dict:
+        """Fill all known information in a dictionary for provenance tracking.
+
+        Returns:
+            dictionary with all argument_name -> argument_value as key -> value pairs.
+        """
+        runtime_args = {
+            "catalog_name": self.output_catalog_name,
+            "output_path": str(self.output_path),
+            "output_catalog_name": self.output_catalog_name,
+            "tmp_dir": str(self.tmp_dir),
+            "overwrite": self.overwrite,
+            "dask_tmp": str(self.dask_tmp),
+            "dask_n_workers": self.dask_n_workers,
+            "dask_threads_per_worker": self.dask_threads_per_worker,
+            "catalog_path": self.catalog_path,
+            "tmp_path": str(self.tmp_path),
+        }
+
+        runtime_args.update(self.additional_provenance_info())
+        provenance_info = {
+            "tool_name": "hipscat_import",
+            "version": version("hipscat-import"),
+            "runtime_args": runtime_args,
+        }
+
+        return provenance_info
+
+    def additional_provenance_info(self):
+        """Any additional provenance info from subclasses"""
+        return {}

--- a/tests/hipscat_import/catalog/test_arguments_commandline.py
+++ b/tests/hipscat_import/catalog/test_arguments_commandline.py
@@ -43,8 +43,8 @@ def test_good_paths(blank_data_dir, tmp_path):
         "csv",
     ]
     args = parse_command_line(good_args)
-    assert args._input_path == blank_data_dir
-    assert args._output_path == tmp_path_name
+    assert args.input_path == blank_data_dir
+    assert tmp_path_name in str(args.catalog_path)
 
 
 def test_good_paths_short_names(blank_data_dir, tmp_path):
@@ -61,5 +61,5 @@ def test_good_paths_short_names(blank_data_dir, tmp_path):
         "csv",
     ]
     args = parse_command_line(good_args)
-    assert args._input_path == blank_data_dir
-    assert args._output_path == tmp_path_name
+    assert args.input_path == blank_data_dir
+    assert tmp_path_name in str(args.catalog_path)

--- a/tests/hipscat_import/catalog/test_map_reduce.py
+++ b/tests/hipscat_import/catalog/test_map_reduce.py
@@ -82,7 +82,7 @@ def test_read_single_fits(formats_fits, tmp_path):
 
 def test_map_headers_wrong(formats_headers_csv, tmp_path):
     """Test loading the a file with non-default headers (without specifying right headers)"""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="header"):
         mr.map_to_pixels(
             input_file=formats_headers_csv,
             file_reader=get_file_reader("csv"),
@@ -273,7 +273,7 @@ def test_reduce_hipscat_index(parquet_shards_dir, assert_parquet_file_ids, tmp_p
 
 def test_reduce_bad_expectation(parquet_shards_dir, tmp_path):
     """Test reducing into one large pixel"""
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Unexpected number of objects"):
         mr.reduce_pixel_shards(
             cache_path=parquet_shards_dir,
             origin_pixel_numbers=[44, 45, 46, 47],

--- a/tests/hipscat_import/catalog/test_resume_files.py
+++ b/tests/hipscat_import/catalog/test_resume_files.py
@@ -4,20 +4,18 @@ import hipscat.pixel_math as hist
 import numpy.testing as npt
 import pytest
 
-from hipscat_import.catalog.resume_files import (
-    clean_resume_files,
-    is_mapping_done,
-    is_reducing_done,
-    read_histogram,
-    read_mapping_keys,
-    read_reducing_keys,
-    set_mapping_done,
-    set_reducing_done,
-    write_histogram,
-    write_mapping_done_key,
-    write_mapping_start_key,
-    write_reducing_key,
-)
+from hipscat_import.catalog.resume_files import (clean_resume_files,
+                                                 is_mapping_done,
+                                                 is_reducing_done,
+                                                 read_histogram,
+                                                 read_mapping_keys,
+                                                 read_reducing_keys,
+                                                 set_mapping_done,
+                                                 set_reducing_done,
+                                                 write_histogram,
+                                                 write_mapping_done_key,
+                                                 write_mapping_start_key,
+                                                 write_reducing_key)
 
 
 def test_mapping_done(tmp_path):
@@ -92,7 +90,7 @@ def test_read_write_mapping_keys_corrupt(tmp_path):
     assert mapping_keys[0] == "key1"
 
     write_mapping_start_key(tmp_path, "key2")
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="logs are corrupted"):
         read_mapping_keys(tmp_path)
 
     clean_resume_files(tmp_path)

--- a/tests/hipscat_import/catalog/test_run_import.py
+++ b/tests/hipscat_import/catalog/test_run_import.py
@@ -20,7 +20,7 @@ def test_empty_args():
 
 def test_bad_args():
     """Runner should fail with mis-typed arguments"""
-    args = {"catalog_name": "bad_arg_type"}
+    args = {"output_catalog_name": "bad_arg_type"}
     with pytest.raises(ValueError):
         runner.run(args)
 
@@ -58,10 +58,10 @@ def test_resume_dask_runner(
         os.path.join(tmp_path, "resume", "Norder=0"),
     )
 
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="resume"):
         ## Check that we fail if there are some existing intermediate files
         ImportArguments(
-            catalog_name="resume",
+            output_catalog_name="resume",
             input_path=small_sky_parts_dir,
             input_format="csv",
             output_path=tmp_path,
@@ -74,7 +74,7 @@ def test_resume_dask_runner(
         )
 
     args = ImportArguments(
-        catalog_name="resume",
+        output_catalog_name="resume",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -129,7 +129,7 @@ def test_resume_dask_runner(
     rf.set_reducing_done(temp_path)
 
     args = ImportArguments(
-        catalog_name="resume",
+        output_catalog_name="resume",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -160,7 +160,7 @@ def test_dask_runner(
 ):
     """Test basic execution."""
     args = ImportArguments(
-        catalog_name="small_sky_object_catalog",
+        output_catalog_name="small_sky_object_catalog",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -212,7 +212,7 @@ def test_dask_runner_source_table(
 ):
     """Test basic execution."""
     args = ImportArguments(
-        catalog_name="small_sky_source_catalog",
+        output_catalog_name="small_sky_source_catalog",
         input_path=small_sky_source_dir,
         input_format="csv",
         catalog_type="source",
@@ -269,7 +269,7 @@ def test_dask_runner_source_table(
 def test_dask_runner_stats_only(dask_client, small_sky_parts_dir, tmp_path):
     """Test basic execution, without generating catalog parquet outputs."""
     args = ImportArguments(
-        catalog_name="small_sky",
+        output_catalog_name="small_sky",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -305,7 +305,7 @@ def test_dask_runner_mixed_schema_csv(
 
     schema_parquet = pd.read_parquet(mixed_schema_csv_parquet)
     args = ImportArguments(
-        catalog_name="mixed_csv",
+        output_catalog_name="mixed_csv",
         input_path=mixed_schema_csv_dir,
         input_format="csv",
         output_path=tmp_path,

--- a/tests/hipscat_import/test_runtime_arguments.py
+++ b/tests/hipscat_import/test_runtime_arguments.py
@@ -1,0 +1,171 @@
+"""Tests of argument validation, in the absense of command line parsing"""
+
+
+import os
+
+import pytest
+
+from hipscat_import.runtime_arguments import RuntimeArguments
+
+# pylint: disable=protected-access
+
+
+def test_none():
+    """No arguments provided. Should error for required args."""
+    with pytest.raises(ValueError):
+        RuntimeArguments()
+
+
+def test_empty_required(tmp_path):
+    """*Most* required arguments are provided."""
+    ## Output path is missing
+    with pytest.raises(ValueError, match="output_path"):
+        RuntimeArguments(
+            output_catalog_name="catalog",
+            output_path="",
+        )
+
+    ## Output catalog name is missing
+    with pytest.raises(ValueError, match="output_catalog_name"):
+        RuntimeArguments(
+            output_catalog_name="",
+            output_path=tmp_path,
+        )
+
+
+def test_catalog_name(tmp_path):
+    """Check for safe catalog names."""
+    RuntimeArguments(
+        output_catalog_name="good_name",
+        output_path=tmp_path,
+    )
+
+    with pytest.raises(ValueError, match="invalid character"):
+        RuntimeArguments(
+            output_catalog_name="bad_a$$_name",
+            output_path=tmp_path,
+        )
+
+
+def test_invalid_paths(tmp_path):
+    """Required arguments are provided, but paths aren't found."""
+    ## Bad output path
+    with pytest.raises(FileNotFoundError):
+        RuntimeArguments(
+            output_catalog_name="catalog",
+            output_path="/foo/path",
+        )
+
+    ## Bad temp path
+    with pytest.raises(FileNotFoundError):
+        RuntimeArguments(
+            output_catalog_name="catalog", output_path=tmp_path, tmp_dir="/foo/path"
+        )
+
+    ## Bad dask temp path
+    with pytest.raises(FileNotFoundError):
+        RuntimeArguments(
+            output_catalog_name="catalog", output_path=tmp_path, dask_tmp="/foo/path"
+        )
+
+
+def test_output_overwrite(tmp_path):
+    """Test that we can write to existing directory, but not one with contents"""
+    ## Create the directory first
+    RuntimeArguments(
+        output_catalog_name="blank",
+        output_path=tmp_path,
+    )
+
+    with pytest.raises(ValueError, match="use --overwrite flag"):
+        RuntimeArguments(
+            output_catalog_name="blank",
+            output_path=tmp_path,
+        )
+
+    ## No error with overwrite flag
+    RuntimeArguments(
+        output_catalog_name="blank",
+        output_path=tmp_path,
+        overwrite=True,
+    )
+
+
+def test_good_paths(tmp_path):
+    """Required arguments are provided, and paths are found."""
+    _ = RuntimeArguments(
+        output_catalog_name="catalog",
+        output_path=tmp_path,
+        tmp_dir=tmp_path,
+        dask_tmp=tmp_path,
+    )
+
+
+def test_tmp_path_creation(tmp_path):
+    """Check that we create a new temp path for this catalog."""
+    output_path = os.path.join(tmp_path, "unique_output_directory")
+    temp_path = os.path.join(tmp_path, "unique_tmp_directory")
+    dask_tmp_path = os.path.join(tmp_path, "unique_dask_directory")
+    os.makedirs(output_path, exist_ok=True)
+    os.makedirs(temp_path, exist_ok=True)
+    os.makedirs(dask_tmp_path, exist_ok=True)
+
+    ## If no tmp paths are given, use the output directory
+    args = RuntimeArguments(
+        output_catalog_name="special_catalog",
+        output_path=output_path,
+    )
+    assert "special_catalog" in str(args.tmp_path)
+    assert "unique_output_directory" in str(args.tmp_path)
+
+    ## Use the tmp path if provided
+    args = RuntimeArguments(
+        output_catalog_name="special_catalog",
+        output_path=output_path,
+        tmp_dir=temp_path,
+        overwrite=True,
+    )
+    assert "special_catalog" in str(args.tmp_path)
+    assert "unique_tmp_directory" in str(args.tmp_path)
+
+    ## Use the dask tmp for temp, if all else fails
+    args = RuntimeArguments(
+        output_catalog_name="special_catalog",
+        output_path=output_path,
+        dask_tmp=dask_tmp_path,
+        overwrite=True,
+    )
+    assert "special_catalog" in str(args.tmp_path)
+    assert "unique_dask_directory" in str(args.tmp_path)
+
+
+def test_dask_args(tmp_path):
+    """Test errors for dask arguments"""
+    with pytest.raises(ValueError, match="dask_n_workers"):
+        RuntimeArguments(
+            output_catalog_name="catalog",
+            output_path=tmp_path,
+            dask_n_workers=-10,
+            dask_threads_per_worker=1,
+        )
+
+    with pytest.raises(ValueError, match="dask_threads_per_worker"):
+        RuntimeArguments(
+            output_catalog_name="catalog",
+            output_path=tmp_path,
+            dask_n_workers=1,
+            dask_threads_per_worker=-10,
+        )
+
+
+def test_provenance_info(tmp_path):
+    """Verify that provenance info ONLY includes general runtime fields."""
+    args = RuntimeArguments(
+        output_catalog_name="catalog",
+        output_path=tmp_path,
+        tmp_dir=tmp_path,
+        dask_tmp=tmp_path,
+    )
+
+    runtime_args = args.provenance_info()["runtime_args"]
+    assert len(runtime_args) == 10


### PR DESCRIPTION
There are a handful of arguments that will be used for creating indexes and equijoin association tables. This pulls those arguments, their validation logic, and the provenance info generation into a parent class.

This should simplify the new classes, as well as reducing duplicated code (which pylint was VERY unhappy about).