### PR TITLE
Require dask_client if not requested.

### DIFF
--- a/tests/hipscat_import/conftest.py
+++ b/tests/hipscat_import/conftest.py
@@ -18,15 +18,27 @@ def dask_client():
 
 
 def pytest_collection_modifyitems(items):
-    """Modify dask unit tests to ignore event loop deprecation warnings and have a longer timeout"""
+    """Modify dask unit tests to 
+        - ignore event loop deprecation warnings
+        - have a longer timeout default timeout (5 seconds instead of 1 second)
+        - require use of the `dask_client` fixture, even if it's not requsted
+
+    Individual tests that will be particularly long-running can still override
+    the default timeout, by using an annotation like:
+
+        @pytest.mark.dask(timeout=10)
+        def test_long_running():
+            ...
+    """
     for item in items:
         timeout = None
         for mark in item.iter_markers(name="dask"):
-            timeout = 3
+            timeout = 5
             if "timeout" in mark.kwargs:
                 timeout = int(mark.kwargs.get("timeout"))
         if timeout:
             item.add_marker(pytest.mark.timeout(timeout))
+            item.add_marker(pytest.mark.usefixtures("dask_client"))
             item.add_marker(pytest.mark.filterwarnings("ignore::DeprecationWarning"))
 
 


### PR DESCRIPTION
When running a single test case, they can fail because no `dask_client` is instantiated, if there's no dask_client requested, but is implicity required for dask dataframe operations.

This requires a dask client fixture for all dask tests, even if `dask_client` is not among requested fixtures for the test case.

Also ups the default timeout, since 3 was pushing it for github workflows.