### PR TITLE
Use type-specific catalog info

### DIFF
--- a/src/hipscat_import/association/arguments.py
+++ b/src/hipscat_import/association/arguments.py
@@ -2,7 +2,8 @@
 
 from dataclasses import dataclass
 
-from hipscat.catalog import CatalogParameters
+from hipscat.catalog.association_catalog.association_catalog import \
+    AssociationCatalogInfo
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -51,17 +52,18 @@ class AssociationArguments(RuntimeArguments):
         if self.compute_partition_size < 100_000:
             raise ValueError("compute_partition_size must be at least 100_000")
 
-    def to_catalog_parameters(self) -> CatalogParameters:
-        """Convert importing arguments into hipscat catalog parameters.
-
-        Returns:
-            CatalogParameters for catalog being created.
-        """
-        return CatalogParameters(
-            catalog_name=self.output_catalog_name,
-            catalog_type="association",
-            output_path=self.output_path,
-        )
+    def to_catalog_info(self, total_rows) -> AssociationCatalogInfo:
+        """Catalog-type-specific dataset info."""
+        info = {
+            "catalog_name": self.output_catalog_name,
+            "catalog_type": "association",
+            "total_rows": total_rows,
+            "primary_column": self.primary_id_column,
+            "primary_catalog": str(self.primary_input_catalog_path),
+            "join_column": self.join_id_column,
+            "join_catalog": str(self.join_input_catalog_path),
+        }
+        return AssociationCatalogInfo(**info)
 
     def additional_runtime_provenance_info(self):
         return {

--- a/src/hipscat_import/association/arguments.py
+++ b/src/hipscat_import/association/arguments.py
@@ -2,8 +2,9 @@
 
 from dataclasses import dataclass
 
-from hipscat.catalog.association_catalog.association_catalog import \
-    AssociationCatalogInfo
+from hipscat.catalog.association_catalog.association_catalog import (
+    AssociationCatalogInfo,
+)
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -65,7 +66,7 @@ class AssociationArguments(RuntimeArguments):
         }
         return AssociationCatalogInfo(**info)
 
-    def additional_runtime_provenance_info(self):
+    def additional_runtime_provenance_info(self) -> dict:
         return {
             "primary_input_catalog_path": str(self.primary_input_catalog_path),
             "primary_id_column": self.primary_id_column,

--- a/src/hipscat_import/association/run_association.py
+++ b/src/hipscat_import/association/run_association.py
@@ -9,7 +9,8 @@ from hipscat.io import file_io, write_metadata
 from tqdm import tqdm
 
 from hipscat_import.association.arguments import AssociationArguments
-from hipscat_import.association.map_reduce import map_association, reduce_association
+from hipscat_import.association.map_reduce import (map_association,
+                                                   reduce_association)
 
 
 def _validate_args(args):
@@ -40,11 +41,17 @@ def run(args):
     ) as step_progress:
         # pylint: disable=duplicate-code
         # Very similar to /index/run_index.py
-        catalog_params = args.to_catalog_parameters()
-        catalog_params.total_rows = int(rows_written)
-        write_metadata.write_provenance_info(catalog_params, args.provenance_info())
+        catalog_info = args.to_catalog_info(int(rows_written))
+        write_metadata.write_provenance_info(
+            catalog_base_dir=args.catalog_path,
+            dataset_info=catalog_info,
+            tool_args=args.provenance_info(),
+        )
         step_progress.update(1)
-        write_metadata.write_catalog_info(catalog_params)
+        catalog_info = args.to_catalog_info(total_rows=int(rows_written))
+        write_metadata.write_catalog_info(
+            dataset_info=catalog_info, catalog_base_dir=args.catalog_path
+        )
         step_progress.update(1)
         write_metadata.write_parquet_metadata(args.catalog_path)
         step_progress.update(1)

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from typing import Callable, List
 
 import pandas as pd
-from hipscat.catalog import CatalogParameters
+from hipscat.catalog.catalog import CatalogInfo
 from hipscat.io import FilePointer, file_io
 from hipscat.pixel_math import hipscat_id
 
@@ -140,19 +140,17 @@ class ImportArguments(RuntimeArguments):
         if not self.filter_function:
             self.filter_function = passthrough_filter_function
 
-    def to_catalog_parameters(self) -> CatalogParameters:
-        """Convert importing arguments into hipscat catalog parameters.
-        Returns:
-            CatalogParameters for catalog being created.
-        """
-        return CatalogParameters(
-            catalog_name=self.output_catalog_name,
-            catalog_type=self.catalog_type,
-            output_path=self.output_path,
-            epoch=self.epoch,
-            ra_column=self.ra_column,
-            dec_column=self.dec_column,
-        )
+    def to_catalog_info(self, total_rows) -> CatalogInfo:
+        """Catalog-type-specific dataset info."""
+        info = {
+            "catalog_name": self.output_catalog_name,
+            "catalog_type": self.catalog_type,
+            "total_rows": total_rows,
+            "epoch": self.epoch,
+            "ra_column": self.ra_column,
+            "dec_column": self.dec_column,
+        }
+        return CatalogInfo(**info)
 
     def additional_runtime_provenance_info(self):
         return {
@@ -180,6 +178,7 @@ def check_healpix_order_range(
 ):
     """Helper method to heck if the `order` is within the range determined by the
     `lower_bound` and `upper_bound`, inclusive.
+
     Args:
         order (int): healpix order to check
         field_name (str): field name to use in the error message

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -152,7 +152,7 @@ class ImportArguments(RuntimeArguments):
         }
         return CatalogInfo(**info)
 
-    def additional_runtime_provenance_info(self):
+    def additional_runtime_provenance_info(self) -> dict:
         return {
             "catalog_name": self.output_catalog_name,
             "epoch": self.epoch,

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -169,7 +169,9 @@ class ImportArguments(RuntimeArguments):
             "pixel_threshold": self.pixel_threshold,
             "mapping_healpix_order": self.mapping_healpix_order,
             "debug_stats_only": self.debug_stats_only,
-            "file_reader_info": self.file_reader.provenance_info(),
+            "file_reader_info": self.file_reader.provenance_info()
+            if self.file_reader is not None
+            else {},
         }
 
 

--- a/src/hipscat_import/index/arguments.py
+++ b/src/hipscat_import/index/arguments.py
@@ -3,7 +3,8 @@
 from dataclasses import dataclass, field
 from typing import List, Optional
 
-from hipscat.catalog import Catalog, CatalogParameters
+from hipscat.catalog import Catalog
+from hipscat.catalog.index.index_catalog_info import IndexCatalogInfo
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -46,17 +47,17 @@ class IndexArguments(RuntimeArguments):
         if self.compute_partition_size < 100_000:
             raise ValueError("compute_partition_size must be at least 100_000")
 
-    def to_catalog_parameters(self) -> CatalogParameters:
-        """Convert importing arguments into hipscat catalog parameters.
-
-        Returns:
-            CatalogParameters for catalog being created.
-        """
-        return CatalogParameters(
-            catalog_name=self.output_catalog_name,
-            catalog_type="index",
-            output_path=self.output_path,
-        )
+    def to_catalog_info(self, total_rows) -> IndexCatalogInfo:
+        """Catalog-type-specific dataset info."""
+        info = {
+            "catalog_name": self.output_catalog_name,
+            "total_rows": total_rows,
+            "catalog_type": "index",
+            "primary_catalog":str(self.input_catalog_path),
+            "indexing_column": self.indexing_column,
+            "extra_columns": self.extra_columns,
+        }
+        return IndexCatalogInfo(**info)
 
     def additional_runtime_provenance_info(self):
         return {

--- a/src/hipscat_import/index/arguments.py
+++ b/src/hipscat_import/index/arguments.py
@@ -53,13 +53,13 @@ class IndexArguments(RuntimeArguments):
             "catalog_name": self.output_catalog_name,
             "total_rows": total_rows,
             "catalog_type": "index",
-            "primary_catalog":str(self.input_catalog_path),
+            "primary_catalog": str(self.input_catalog_path),
             "indexing_column": self.indexing_column,
             "extra_columns": self.extra_columns,
         }
         return IndexCatalogInfo(**info)
 
-    def additional_runtime_provenance_info(self):
+    def additional_runtime_provenance_info(self) -> dict:
         return {
             "input_catalog_path": str(self.input_catalog_path),
             "indexing_column": self.indexing_column,

--- a/src/hipscat_import/index/run_index.py
+++ b/src/hipscat_import/index/run_index.py
@@ -25,11 +25,16 @@ def run(args):
     ) as step_progress:
         # pylint: disable=duplicate-code
         # Very similar to /association/run_association.py
-        catalog_params = args.to_catalog_parameters()
-        catalog_params.total_rows = int(rows_written)
-        write_metadata.write_provenance_info(catalog_params, args.provenance_info())
+        catalog_info = args.to_catalog_info(int(rows_written))
+        write_metadata.write_provenance_info(
+            catalog_base_dir=args.catalog_path,
+            dataset_info=catalog_info,
+            tool_args=args.provenance_info(),
+        )
         step_progress.update(1)
-        write_metadata.write_catalog_info(catalog_params)
+        write_metadata.write_catalog_info(
+            catalog_base_dir=args.catalog_path, dataset_info=catalog_info
+        )
         step_progress.update(1)
         file_io.remove_directory(args.tmp_path, ignore_errors=True)
         step_progress.update(1)

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -4,6 +4,9 @@ from dataclasses import dataclass
 import healpy as hp
 import numpy as np
 from hipscat.catalog import Catalog
+from hipscat.catalog.margin_cache.margin_cache_catalog_info import (
+    MarginCacheCatalogInfo,
+)
 from hipscat.io import file_io
 
 from hipscat_import.runtime_arguments import RuntimeArguments
@@ -53,9 +56,30 @@ class MarginCacheArguments(RuntimeArguments):
 
         margin_pixel_nside = hp.order2nside(self.margin_order)
 
-        if hp.nside2resol(margin_pixel_nside, arcmin=True) * 60. < self.margin_threshold:
+        if (
+            hp.nside2resol(margin_pixel_nside, arcmin=True) * 60.0
+            < self.margin_threshold
+        ):
             # pylint: disable=line-too-long
             warnings.warn(
                 "Warning: margin pixels have a smaller resolution than margin_threshold; this may lead to data loss in the margin cache."
             )
             # pylint: enable=line-too-long
+
+    def to_catalog_info(self, total_rows) -> MarginCacheCatalogInfo:
+        """Catalog-type-specific dataset info."""
+        info = {
+            "catalog_name": self.output_catalog_name,
+            "total_rows": total_rows,
+            "catalog_type": "margin",
+            "primary_catalog": self.input_catalog_path,
+            "margin_threshold": self.margin_threshold,
+        }
+        return MarginCacheCatalogInfo(**info)
+
+    def additional_runtime_provenance_info(self):
+        return {
+            "input_catalog_path": str(self.input_catalog_path),
+            "margin_threshold": self.margin_threshold,
+            "margin_order": self.margin_order,
+        }

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -77,7 +77,7 @@ class MarginCacheArguments(RuntimeArguments):
         }
         return MarginCacheCatalogInfo(**info)
 
-    def additional_runtime_provenance_info(self):
+    def additional_runtime_provenance_info(self) -> dict:
         return {
             "input_catalog_path": str(self.input_catalog_path),
             "margin_threshold": self.margin_threshold,

--- a/tests/hipscat_import/association/test_association_argument.py
+++ b/tests/hipscat_import/association/test_association_argument.py
@@ -181,8 +181,8 @@ def test_all_required_args(tmp_path, small_sky_object_catalog):
     )
 
 
-def test_to_catalog_parameters(small_sky_object_catalog, tmp_path):
-    """Verify creation of catalog parameters for index to be created."""
+def test_to_catalog_info(small_sky_object_catalog, tmp_path):
+    """Verify creation of catalog parameters for association table to be created."""
     args = AssociationArguments(
         primary_input_catalog_path=small_sky_object_catalog,
         primary_id_column="id",
@@ -193,8 +193,9 @@ def test_to_catalog_parameters(small_sky_object_catalog, tmp_path):
         output_path=tmp_path,
         output_catalog_name="small_sky_self_join",
     )
-    catalog_parameters = args.to_catalog_parameters()
-    assert catalog_parameters.catalog_name == args.output_catalog_name
+    catalog_info = args.to_catalog_info(total_rows=10)
+    assert catalog_info.catalog_name == args.output_catalog_name
+    assert catalog_info.total_rows == 10
 
 
 def test_provenance_info(small_sky_object_catalog, tmp_path):

--- a/tests/hipscat_import/association/test_run_association.py
+++ b/tests/hipscat_import/association/test_run_association.py
@@ -6,6 +6,8 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
+from hipscat.catalog.association_catalog.association_catalog import \
+    AssociationCatalog
 
 import hipscat_import.association.run_association as runner
 from hipscat_import.association.arguments import AssociationArguments
@@ -29,9 +31,8 @@ def test_object_to_source(
     small_sky_object_catalog,
     small_sky_source_catalog,
     tmp_path,
-    assert_text_file_matches,
 ):
-    """test stuff"""
+    """Test creating association between object and source catalogs."""
 
     args = AssociationArguments(
         primary_input_catalog_path=small_sky_object_catalog,
@@ -46,40 +47,11 @@ def test_object_to_source(
     )
     runner.run(args)
 
-    # Check that the catalog metadata file exists
-    expected_metadata_lines = [
-        "{",
-        '    "catalog_name": "small_sky_association",',
-        '    "catalog_type": "association",',
-        '    "epoch": "J2000",',
-        '    "ra_kw": "ra",',
-        '    "dec_kw": "dec",',
-        '    "total_rows": 17161',
-        "}",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "catalog_info.json")
-    assert_text_file_matches(expected_metadata_lines, metadata_filename)
-
-    # Check that the partition *join* info file exists
-    expected_lines = [
-        "Norder,Dir,Npix,join_Norder,join_Dir,join_Npix,num_rows",
-        "0,0,11,0,0,4,50",
-        "0,0,11,1,0,47,2395",
-        "0,0,11,2,0,176,385",
-        "0,0,11,2,0,177,1510",
-        "0,0,11,2,0,178,1634",
-        "0,0,11,2,0,179,1773",
-        "0,0,11,2,0,180,655",
-        "0,0,11,2,0,181,903",
-        "0,0,11,2,0,182,1246",
-        "0,0,11,2,0,183,1143",
-        "0,0,11,2,0,184,1390",
-        "0,0,11,2,0,185,2942",
-        "0,0,11,2,0,186,452",
-        "0,0,11,2,0,187,683",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "partition_join_info.csv")
-    assert_text_file_matches(expected_lines, metadata_filename)
+    ## Check that the association data can be parsed as a valid association catalog.
+    catalog = AssociationCatalog.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
+    assert len(catalog.get_join_pixels()) == 14
 
     ## Test one pixel that will have 50 rows in it.
     output_file = os.path.join(
@@ -105,15 +77,19 @@ def test_object_to_source(
     ids = data_frame["join_id"]
     assert np.logical_and(ids >= 70_000, ids < 87161).all()
 
+    catalog = AssociationCatalog.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
+    assert len(catalog.get_join_pixels()) == 14
+
 
 @pytest.mark.dask
 def test_source_to_object(
     small_sky_object_catalog,
     small_sky_source_catalog,
     tmp_path,
-    assert_text_file_matches,
 ):
-    """test stuff"""
+    """Test creating (weirder) association between source and object catalogs."""
 
     args = AssociationArguments(
         primary_input_catalog_path=small_sky_source_catalog,
@@ -128,40 +104,11 @@ def test_source_to_object(
     )
     runner.run(args)
 
-    # Check that the catalog metadata file exists
-    expected_metadata_lines = [
-        "{",
-        '    "catalog_name": "small_sky_association",',
-        '    "catalog_type": "association",',
-        '    "epoch": "J2000",',
-        '    "ra_kw": "ra",',
-        '    "dec_kw": "dec",',
-        '    "total_rows": 17161',
-        "}",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "catalog_info.json")
-    assert_text_file_matches(expected_metadata_lines, metadata_filename)
-
-    # Check that the partition *join* info file exists
-    expected_lines = [
-        "Norder,Dir,Npix,join_Norder,join_Dir,join_Npix,num_rows",
-        "0,0,4,0,0,11,50",
-        "1,0,47,0,0,11,2395",
-        "2,0,176,0,0,11,385",
-        "2,0,177,0,0,11,1510",
-        "2,0,178,0,0,11,1634",
-        "2,0,179,0,0,11,1773",
-        "2,0,180,0,0,11,655",
-        "2,0,181,0,0,11,903",
-        "2,0,182,0,0,11,1246",
-        "2,0,183,0,0,11,1143",
-        "2,0,184,0,0,11,1390",
-        "2,0,185,0,0,11,2942",
-        "2,0,186,0,0,11,452",
-        "2,0,187,0,0,11,683",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "partition_join_info.csv")
-    assert_text_file_matches(expected_lines, metadata_filename)
+    ## Check that the association data can be parsed as a valid association catalog.
+    catalog = AssociationCatalog.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
+    assert len(catalog.get_join_pixels()) == 14
 
     ## Test one pixel that will have 50 rows in it.
     output_file = os.path.join(
@@ -192,9 +139,8 @@ def test_source_to_object(
 def test_self_join(
     small_sky_object_catalog,
     tmp_path,
-    assert_text_file_matches,
 ):
-    """test stuff"""
+    """Test creating association between object catalog and itself."""
 
     args = AssociationArguments(
         primary_input_catalog_path=small_sky_object_catalog,
@@ -209,27 +155,11 @@ def test_self_join(
     )
     runner.run(args)
 
-    # Check that the catalog metadata file exists
-    expected_metadata_lines = [
-        "{",
-        '    "catalog_name": "small_sky_self_association",',
-        '    "catalog_type": "association",',
-        '    "epoch": "J2000",',
-        '    "ra_kw": "ra",',
-        '    "dec_kw": "dec",',
-        '    "total_rows": 131',
-        "}",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "catalog_info.json")
-    assert_text_file_matches(expected_metadata_lines, metadata_filename)
-
-    # Check that the partition *join* info file exists
-    expected_lines = [
-        "Norder,Dir,Npix,join_Norder,join_Dir,join_Npix,num_rows",
-        "0,0,11,0,0,11,131",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "partition_join_info.csv")
-    assert_text_file_matches(expected_lines, metadata_filename)
+    ## Check that the association data can be parsed as a valid association catalog.
+    catalog = AssociationCatalog.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
+    assert len(catalog.get_join_pixels()) == 1
 
     ## Test one pixel that will have 50 rows in it.
     output_file = os.path.join(

--- a/tests/hipscat_import/catalog/test_argument_validation.py
+++ b/tests/hipscat_import/catalog/test_argument_validation.py
@@ -3,7 +3,8 @@
 
 import pytest
 
-from hipscat_import.catalog.arguments import ImportArguments, check_healpix_order_range
+from hipscat_import.catalog.arguments import (ImportArguments,
+                                              check_healpix_order_range)
 
 # pylint: disable=protected-access
 
@@ -168,7 +169,7 @@ def test_catalog_type(blank_data_dir, tmp_path):
         )
 
 
-def test_to_catalog_parameters(blank_data_dir, tmp_path):
+def test_to_catalog_info(blank_data_dir, tmp_path):
     """Verify creation of catalog parameters for catalog to be created."""
     args = ImportArguments(
         output_catalog_name="catalog",
@@ -177,8 +178,9 @@ def test_to_catalog_parameters(blank_data_dir, tmp_path):
         output_path=tmp_path,
         tmp_dir=tmp_path,
     )
-    catalog_parameters = args.to_catalog_parameters()
-    assert catalog_parameters.catalog_name == "catalog"
+    catalog_info = args.to_catalog_info(total_rows=10)
+    assert catalog_info.catalog_name == "catalog"
+    assert catalog_info.total_rows == 10
 
 
 def test_provenance_info(blank_data_dir, tmp_path):

--- a/tests/hipscat_import/catalog/test_argument_validation.py
+++ b/tests/hipscat_import/catalog/test_argument_validation.py
@@ -3,8 +3,7 @@
 
 import pytest
 
-from hipscat_import.catalog.arguments import (ImportArguments,
-                                              check_healpix_order_range)
+from hipscat_import.catalog.arguments import ImportArguments, check_healpix_order_range
 
 # pylint: disable=protected-access
 

--- a/tests/hipscat_import/catalog/test_file_readers.py
+++ b/tests/hipscat_import/catalog/test_file_readers.py
@@ -9,9 +9,12 @@ import pyarrow.parquet as pq
 import pytest
 from hipscat.catalog.catalog import CatalogInfo
 
-from hipscat_import.catalog.file_readers import (CsvReader, FitsReader,
-                                                 ParquetReader,
-                                                 get_file_reader)
+from hipscat_import.catalog.file_readers import (
+    CsvReader,
+    FitsReader,
+    ParquetReader,
+    get_file_reader,
+)
 
 
 # pylint: disable=redefined-outer-name
@@ -25,6 +28,7 @@ def basic_catalog_info():
         "dec_column": "dec",
     }
     return CatalogInfo(**info)
+
 
 def test_unknown_file_type():
     """File reader factory method should fail for unknown file types"""

--- a/tests/hipscat_import/catalog/test_run_round_trip.py
+++ b/tests/hipscat_import/catalog/test_run_round_trip.py
@@ -11,6 +11,7 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
+from hipscat.catalog.catalog import Catalog
 
 import hipscat_import.catalog.run_import as runner
 from hipscat_import.catalog.arguments import ImportArguments
@@ -21,7 +22,6 @@ from hipscat_import.catalog.file_readers import get_file_reader
 def test_import_source_table(
     dask_client,
     small_sky_source_dir,
-    assert_text_file_matches,
     tmp_path,
 ):
     """Test basic execution, using a larger source file.
@@ -47,39 +47,12 @@ def test_import_source_table(
     runner.run_with_client(args, dask_client)
 
     # Check that the catalog metadata file exists
-    expected_lines = [
-        "{",
-        '    "catalog_name": "small_sky_source_catalog",',
-        '    "catalog_type": "source",',
-        '    "epoch": "J2000",',
-        '    "ra_kw": "source_ra",',
-        '    "dec_kw": "source_dec",',
-        '    "total_rows": 17161',
-        "}",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "catalog_info.json")
-    assert_text_file_matches(expected_lines, metadata_filename)
-
-    # Check that the partition info file exists
-    expected_lines = [
-        "Norder,Dir,Npix,num_rows",
-        "0,0,4,50",
-        "1,0,47,2395",
-        "2,0,176,385",
-        "2,0,177,1510",
-        "2,0,178,1634",
-        "2,0,179,1773",
-        "2,0,180,655",
-        "2,0,181,903",
-        "2,0,182,1246",
-        "2,0,183,1143",
-        "2,0,184,1390",
-        "2,0,185,2942",
-        "2,0,186,452",
-        "2,0,187,683",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "partition_info.csv")
-    assert_text_file_matches(expected_lines, metadata_filename)
+    catalog = Catalog.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
+    assert catalog.catalog_info.ra_column == "source_ra"
+    assert catalog.catalog_info.dec_column == "source_dec"
+    assert len(catalog.get_pixels()) == 14
 
 
 @pytest.mark.dask
@@ -131,8 +104,8 @@ def test_import_preserve_index(
 ):
     """Test basic execution, with input with pandas metadata.
     - the input file is a parquet file with some pandas metadata.
-        this verifies that the parquet file at the end also has pandas 
-        metadata, and the user's preferred id is retained as the index, 
+        this verifies that the parquet file at the end also has pandas
+        metadata, and the user's preferred id is retained as the index,
         when requested.
     """
 
@@ -222,8 +195,8 @@ def test_import_multiindex(
     """Test basic execution, with input with pandas metadata
     - this is *similar* to the above test
     - the input file is a parquet file with a multi-level pandas index.
-        this verifies that the parquet file at the end also has pandas 
-        metadata, and the user's preferred id is retained as the index, 
+        this verifies that the parquet file at the end also has pandas
+        metadata, and the user's preferred id is retained as the index,
         when requested.
     """
 
@@ -310,7 +283,6 @@ def test_import_multiindex(
 def test_import_constant_healpix_order(
     dask_client,
     small_sky_parts_dir,
-    assert_text_file_matches,
     tmp_path,
 ):
     """Test basic execution.
@@ -329,40 +301,12 @@ def test_import_constant_healpix_order(
 
     runner.run_with_client(args, dask_client)
 
-    # Check that the partition info file exists - all pixels at order 2!
-    expected_lines = [
-        "Norder,Dir,Npix,num_rows",
-        "2,0,176,4",
-        "2,0,177,11",
-        "2,0,178,14",
-        "2,0,179,13",
-        "2,0,180,5",
-        "2,0,181,7",
-        "2,0,182,8",
-        "2,0,183,9",
-        "2,0,184,11",
-        "2,0,185,23",
-        "2,0,186,4",
-        "2,0,187,4",
-        "2,0,188,17",
-        "2,0,190,1",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "partition_info.csv")
-    assert_text_file_matches(expected_lines, metadata_filename)
-
     # Check that the catalog metadata file exists
-    expected_lines = [
-        "{",
-        '    "catalog_name": "small_sky_object_catalog",',
-        '    "catalog_type": "object",',
-        '    "epoch": "J2000",',
-        '    "ra_kw": "ra",',
-        '    "dec_kw": "dec",',
-        '    "total_rows": 131',
-        "}",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "catalog_info.json")
-    assert_text_file_matches(expected_lines, metadata_filename)
+    catalog = Catalog.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
+    # Check that the partition info file exists - all pixels at order 2!
+    assert all(pixel.order == 2 for pixel in catalog.partition_info.get_healpix_pixels())
 
     # Pick a parquet file and make sure it contains as many rows as we expect
     output_file = os.path.join(

--- a/tests/hipscat_import/data/small_sky_object_catalog/catalog_info.json
+++ b/tests/hipscat_import/data/small_sky_object_catalog/catalog_info.json
@@ -1,8 +1,8 @@
 {
     "catalog_name": "small_sky_object_catalog",
     "catalog_type": "object",
+    "total_rows": 131,
     "epoch": "J2000",
-    "ra_kw": "ra",
-    "dec_kw": "dec",
-    "total_rows": 131
+    "ra_column": "ra",
+    "dec_column": "dec"
 }

--- a/tests/hipscat_import/data/small_sky_source_catalog/catalog_info.json
+++ b/tests/hipscat_import/data/small_sky_source_catalog/catalog_info.json
@@ -1,8 +1,8 @@
 {
     "catalog_name": "small_sky_source_catalog",
     "catalog_type": "source",
+    "total_rows": 17161,
     "epoch": "J2000",
     "ra_column": "source_ra",
-    "dec_column": "source_dec",
-    "total_rows": 17161
+    "dec_column": "source_dec"
 }

--- a/tests/hipscat_import/index/test_index_argument.py
+++ b/tests/hipscat_import/index/test_index_argument.py
@@ -128,7 +128,7 @@ def test_compute_partition_size(tmp_path, small_sky_object_catalog):
         )
 
 
-def test_to_catalog_parameters(small_sky_object_catalog, tmp_path):
+def test_to_catalog_info(small_sky_object_catalog, tmp_path):
     """Verify creation of catalog parameters for index to be created."""
     args = IndexArguments(
         input_catalog_path=small_sky_object_catalog,
@@ -138,8 +138,9 @@ def test_to_catalog_parameters(small_sky_object_catalog, tmp_path):
         include_hipscat_index=True,
         include_order_pixel=True,
     )
-    catalog_parameters = args.to_catalog_parameters()
-    assert catalog_parameters.catalog_name == args.output_catalog_name
+    catalog_info = args.to_catalog_info(total_rows=10)
+    assert catalog_info.catalog_name == args.output_catalog_name
+    assert catalog_info.total_rows == 10
 
 
 def test_provenance_info(small_sky_object_catalog, tmp_path):

--- a/tests/hipscat_import/index/test_run_index.py
+++ b/tests/hipscat_import/index/test_run_index.py
@@ -5,6 +5,7 @@ import os
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from hipscat.catalog.dataset.dataset import Dataset
 
 import hipscat_import.index.run_index as runner
 from hipscat_import.index.arguments import IndexArguments
@@ -27,7 +28,6 @@ def test_bad_args():
 def test_run_index(
     small_sky_object_catalog,
     tmp_path,
-    assert_text_file_matches,
 ):
     """Test appropriate metadata is written"""
 
@@ -42,18 +42,9 @@ def test_run_index(
     runner.run(args)
 
     # Check that the catalog metadata file exists
-    expected_metadata_lines = [
-        "{",
-        '    "catalog_name": "small_sky_object_index",',
-        '    "catalog_type": "index",',
-        '    "epoch": "J2000",',
-        '    "ra_kw": "ra",',
-        '    "dec_kw": "dec",',
-        '    "total_rows": 131',
-        "}",
-    ]
-    metadata_filename = os.path.join(args.catalog_path, "catalog_info.json")
-    assert_text_file_matches(expected_metadata_lines, metadata_filename)
+    catalog = Dataset.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
 
     basic_index_parquet_schema = pa.schema(
         [

--- a/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
@@ -7,6 +7,7 @@ from hipscat_import.margin_cache import MarginCacheArguments
 
 # pylint: disable=protected-access
 
+
 def test_empty_required(tmp_path):
     """*Most* required arguments are provided."""
     ## Input catalog path is missing
@@ -16,6 +17,7 @@ def test_empty_required(tmp_path):
             output_path=tmp_path,
             output_catalog_name="catalog_cache",
         )
+
 
 def test_margin_order_dynamic(small_sky_source_catalog, tmp_path):
     """Ensure we can dynamically set the margin_order"""
@@ -28,6 +30,7 @@ def test_margin_order_dynamic(small_sky_source_catalog, tmp_path):
 
     assert args.margin_order == 3
 
+
 def test_margin_order_static(small_sky_source_catalog, tmp_path):
     """Ensure we can manually set the margin_order"""
     args = MarginCacheArguments(
@@ -35,10 +38,11 @@ def test_margin_order_static(small_sky_source_catalog, tmp_path):
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
         output_catalog_name="catalog_cache",
-        margin_order=4
+        margin_order=4,
     )
 
     assert args.margin_order == 4
+
 
 def test_margin_order_invalid(small_sky_source_catalog, tmp_path):
     """Ensure we raise an exception when margin_order is invalid"""
@@ -48,8 +52,9 @@ def test_margin_order_invalid(small_sky_source_catalog, tmp_path):
             input_catalog_path=small_sky_source_catalog,
             output_path=tmp_path,
             output_catalog_name="catalog_cache",
-            margin_order=2
+            margin_order=2,
         )
+
 
 def test_margin_threshold_warns(small_sky_source_catalog, tmp_path):
     """Ensure we give a warning when margin_threshold is greater than margin_order resolution"""
@@ -60,7 +65,7 @@ def test_margin_threshold_warns(small_sky_source_catalog, tmp_path):
             input_catalog_path=small_sky_source_catalog,
             output_path=tmp_path,
             output_catalog_name="catalog_cache",
-            margin_order=16
+            margin_order=16,
         )
 
 
@@ -71,7 +76,7 @@ def test_to_catalog_info(small_sky_source_catalog, tmp_path):
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
         output_catalog_name="catalog_cache",
-        margin_order=4
+        margin_order=4,
     )
     catalog_info = args.to_catalog_info(total_rows=10)
     assert catalog_info.catalog_name == args.output_catalog_name
@@ -85,7 +90,7 @@ def test_provenance_info(small_sky_source_catalog, tmp_path):
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
         output_catalog_name="catalog_cache",
-        margin_order=4
+        margin_order=4,
     )
 
     runtime_args = args.provenance_info()["runtime_args"]

--- a/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
@@ -62,3 +62,31 @@ def test_margin_threshold_warns(small_sky_source_catalog, tmp_path):
             output_catalog_name="catalog_cache",
             margin_order=16
         )
+
+
+def test_to_catalog_info(small_sky_source_catalog, tmp_path):
+    """Verify creation of catalog info for margin cache to be created."""
+    args = MarginCacheArguments(
+        margin_threshold=5.0,
+        input_catalog_path=small_sky_source_catalog,
+        output_path=tmp_path,
+        output_catalog_name="catalog_cache",
+        margin_order=4
+    )
+    catalog_info = args.to_catalog_info(total_rows=10)
+    assert catalog_info.catalog_name == args.output_catalog_name
+    assert catalog_info.total_rows == 10
+
+
+def test_provenance_info(small_sky_source_catalog, tmp_path):
+    """Verify that provenance info includes margin-cache-specific fields."""
+    args = MarginCacheArguments(
+        margin_threshold=5.0,
+        input_catalog_path=small_sky_source_catalog,
+        output_path=tmp_path,
+        output_catalog_name="catalog_cache",
+        margin_order=4
+    )
+
+    runtime_args = args.provenance_info()["runtime_args"]
+    assert "margin_threshold" in runtime_args


### PR DESCRIPTION
## Change Description

Create catalog-type-specific metadata in the resulting `catalog_info.json` file.

## Solution Description

Uses the new subclasses defined in https://github.com/astronomy-commons/hipscat/pull/101 , and requires hipscat v0.0.12

## Code Quality
- [x] I have read the [Contribution Guide](https://lincc-ppt.readthedocs.io/en/latest/source/contributing.html)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
