### PR TITLE
Add unit tests for dask-on-ray.

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -33,3 +33,4 @@ jobs:
     - name: Run unit tests with pytest
       run: |
         python -m pytest tests
+        python -m pytest tests --use_ray

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -32,5 +32,6 @@ jobs:
     - name: Run unit tests with pytest
       run: |
         python -m pytest tests --cov=hipscat_import --cov-report=xml
+        python -m pytest tests --use_ray
     - name: Upload coverage report to codecov
       uses: codecov/codecov-action@v3

--- a/.github/workflows/type-checking.yml
+++ b/.github/workflows/type-checking.yml
@@ -32,5 +32,5 @@ jobs:
     - name: Analyze code with mypy
 
       run: |
-        mypy ./src ./tests --ignore-missing-imports
+        mypy ./src --ignore-missing-imports
 

--- a/docs/guide/dask_on_ray.rst
+++ b/docs/guide/dask_on_ray.rst
@@ -1,0 +1,46 @@
+Using dask-on-ray
+===============================================================================
+
+What is it?
+-------------------------------------------------------------------------------
+
+See more on Ray's site:
+
+https://docs.ray.io/en/latest/ray-more-libs/dask-on-ray.html
+
+How to use in hipscat-import pipelines
+-------------------------------------------------------------------------------
+
+Install ray
+
+.. code-block:: python
+
+    pip install ray
+
+Create your client within a ray initialization context and enable dask_on_ray.
+
+You should also disable ray when you're done, just to clean things up.
+
+.. code-block:: python
+
+    import ray
+    from dask.distributed import Client
+    from ray.util.dask import disable_dask_on_ray, enable_dask_on_ray
+
+    from hipscat_import.pipeline import pipeline_with_client
+
+    with ray.init(
+        num_cpus=args.dask_n_workers,
+        _temp_dir=args.dask_tmp,
+    ):
+        enable_dask_on_ray()
+
+        with Client(
+            local_directory=args.dask_tmp,
+            n_workers=args.dask_n_workers
+        ) as client:
+            pipeline_with_client(args, client)
+
+        disable_dask_on_ray()
+
+Your pipeline should execute as though it were using ray for task workers.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -70,6 +70,7 @@ and then wait:
    guide/association
    guide/index_table   
    Notebooks <notebooks>
+   guide/dask_on_ray
 
 .. toctree::
    :hidden:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "ipython", # Also used in building notebooks into Sphinx
     "matplotlib", # Used in sample notebook intro_notebook.ipynb
     "numpy", # Used in sample notebook intro_notebook.ipynb
+    "ray", # Used for dask-on-ray testing.
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,48 @@
+"""Top-level testing configuration."""
+
+import os
+
+import pytest
+import ray
+from dask.distributed import Client
+from ray.util.dask import disable_dask_on_ray, enable_dask_on_ray
+
+# pylint: disable=missing-function-docstring, redefined-outer-name
+
+
+@pytest.fixture(scope="session", name="use_ray")
+def use_ray(request):
+    return request.config.getoption("--use_ray")
+
+
+@pytest.fixture(scope="session", name="dask_client")
+def dask_client(use_ray):
+    """Create a single client for use by all unit test cases."""
+    if use_ray:
+        ray.init(num_cpus=1)
+        enable_dask_on_ray()
+        ## Default values that are not set in a pytest environment.
+        os.environ["RAY_memory_monitor_refresh_ms"] = "250"
+        os.environ["RAY_memory_usage_threshold"] = ".95"
+
+        client = Client()
+        yield client
+        client.close()
+
+        disable_dask_on_ray()
+    else:
+        client = Client()
+        yield client
+        client.close()
+
+
+def pytest_addoption(parser):
+    """Add command line option to test dask unit tests on ray.
+
+    This must live in /tests/conftest.py (not /tests/hipscat-import/conftest.py)"""
+    parser.addoption(
+        "--use_ray",
+        action="store_true",
+        default=False,
+        help="use dask-on-ray for dask tests",
+    )

--- a/tests/hipscat_import/association/test_run_association.py
+++ b/tests/hipscat_import/association/test_run_association.py
@@ -25,7 +25,7 @@ def test_bad_args():
         runner.run(args)
 
 
-@pytest.mark.dask
+@pytest.mark.dask(skip_ray=True)
 def test_object_to_source(
     small_sky_object_catalog,
     small_sky_source_catalog,
@@ -82,7 +82,7 @@ def test_object_to_source(
     assert len(catalog.get_join_pixels()) == 14
 
 
-@pytest.mark.dask
+@pytest.mark.dask(skip_ray=True)
 def test_source_to_object(
     small_sky_object_catalog,
     small_sky_source_catalog,

--- a/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
@@ -65,6 +65,7 @@ def test_to_pixel_shard_polar(tmp_path, polar_data_shard_df):
     validate_result_dataframe(path, 317)
 
 
+@pytest.mark.dask
 def test_reduce_margin_shards(tmp_path, basic_data_shard_df):
     partition_dir = margin_cache_map_reduce._get_partition_directory(tmp_path, 1, 21)
     shard_dir = paths.pixel_directory(partition_dir, 1, 21)


### PR DESCRIPTION
## Change Description

Adds a command line option and pytest fixtures to re-run the whole unit test suite using a dask-on-ray client, instead of vanilla dask.

Notes:
- The association pipeline doesn't work currently on dask-on-ray. I'd rather just remove the whole pipeline than figure out why.
- Instead of having the ray-enabled pipeline in this repo, this just adds a page in the RTD. This avoids an additional package dependency.
- I imagine some of this could be re-used for LSDB testing, if we would like to support a dask-on-ray model there as well.

## Code Quality
- [x] I have read the [Contribution Guide](https://lincc-ppt.readthedocs.io/en/latest/source/contributing.html)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation