### PR TITLE
Use minimum stage name formatting.

### DIFF
--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -40,7 +40,9 @@ class ResumePlan(PipelineResumePlan):
 
     def gather_plan(self):
         """Initialize the plan."""
-        with tqdm(total=5, desc="Planning ", disable=not self.progress_bar) as step_progress:
+        with tqdm(
+            total=4, desc=self.get_formatted_stage_name("Planning"), disable=not self.progress_bar
+        ) as step_progress:
             ## Make sure it's safe to use existing resume state.
             super().safe_to_resume()
             step_progress.update(1)
@@ -71,7 +73,6 @@ class ResumePlan(PipelineResumePlan):
             step_progress.update(1)
 
             ## Gather keys for execution.
-            step_progress.update(1)
             if not mapping_done:
                 mapped_keys = set(self.read_log_keys(self.MAPPING_STAGE))
                 self.map_files = [

--- a/src/hipscat_import/catalog/run_import.py
+++ b/src/hipscat_import/catalog/run_import.py
@@ -12,6 +12,7 @@ from tqdm import tqdm
 
 import hipscat_import.catalog.map_reduce as mr
 from hipscat_import.catalog.arguments import ImportArguments
+from hipscat_import.pipeline_resume_plan import PipelineResumePlan
 
 
 def _map_pixels(args, client):
@@ -106,7 +107,9 @@ def run(args, client):
         raise ValueError("args must be type ImportArguments")
     _map_pixels(args, client)
 
-    with tqdm(total=2, desc="Binning  ", disable=not args.progress_bar) as step_progress:
+    with tqdm(
+        total=2, desc=PipelineResumePlan.get_formatted_stage_name("Binning"), disable=not args.progress_bar
+    ) as step_progress:
         raw_histogram = args.resume_plan.read_histogram(args.mapping_healpix_order)
         step_progress.update(1)
         if args.constant_healpix_order >= 0:
@@ -141,7 +144,9 @@ def run(args, client):
         _reduce_pixels(args, destination_pixel_map, client)
 
     # All done - write out the metadata
-    with tqdm(total=6, desc="Finishing", disable=not args.progress_bar) as step_progress:
+    with tqdm(
+        total=6, desc=PipelineResumePlan.get_formatted_stage_name("Finishing"), disable=not args.progress_bar
+    ) as step_progress:
         catalog_info = args.to_catalog_info(int(raw_histogram.sum()))
         io.write_provenance_info(
             catalog_base_dir=args.catalog_path,

--- a/src/hipscat_import/index/run_index.py
+++ b/src/hipscat_import/index/run_index.py
@@ -5,6 +5,7 @@ from tqdm import tqdm
 
 import hipscat_import.index.map_reduce as mr
 from hipscat_import.index.arguments import IndexArguments
+from hipscat_import.pipeline_resume_plan import PipelineResumePlan
 
 
 def run(args):
@@ -16,7 +17,9 @@ def run(args):
     rows_written = mr.create_index(args)
 
     # All done - write out the metadata
-    with tqdm(total=4, desc="Finishing", disable=not args.progress_bar) as step_progress:
+    with tqdm(
+        total=4, desc=PipelineResumePlan.get_formatted_stage_name("Finishing"), disable=not args.progress_bar
+    ) as step_progress:
         # pylint: disable=duplicate-code
         catalog_info = args.to_catalog_info(int(rows_written))
         write_metadata.write_provenance_info(

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -110,9 +110,10 @@ class PipelineResumePlan:
             stage_name(str): name of the stage (e.g. mapping, reducing)
         """
         some_error = False
+        formatted_stage_name = self.get_formatted_stage_name(stage_name)
         for future in tqdm(
             as_completed(futures),
-            desc=stage_name,
+            desc=formatted_stage_name,
             total=len(futures),
             disable=(not self.progress_bar),
         ):
@@ -123,3 +124,16 @@ class PipelineResumePlan:
         if some_error:  # pragma: no cover
             raise RuntimeError(f"Some {stage_name} stages failed. See logs for details.")
         self.touch_done_file(stage_name)
+
+    @staticmethod
+    def get_formatted_stage_name(stage_name) -> str:
+        """Create a stage name of consistent minimum length. Ensures that the tqdm
+        progress bars can line up nicely when multiple stages must run.
+
+        Args:
+            stage_name (str): name of the stage (e.g. mapping, reducing)
+        """
+        if stage_name is None or len(stage_name) == 0:
+            stage_name = "progress"
+
+        return f"{stage_name.capitalize(): <10}"

--- a/src/hipscat_import/soap/resume_plan.py
+++ b/src/hipscat_import/soap/resume_plan.py
@@ -35,7 +35,9 @@ class SoapPlan(PipelineResumePlan):
 
     def gather_plan(self, args):
         """Initialize the plan."""
-        with tqdm(total=5, desc="Planning ", disable=not self.progress_bar) as step_progress:
+        with tqdm(
+            total=3, desc=self.get_formatted_stage_name("Planning"), disable=not self.progress_bar
+        ) as step_progress:
             ## Make sure it's safe to use existing resume state.
             super().safe_to_resume()
             step_progress.update(1)

--- a/src/hipscat_import/soap/run_soap.py
+++ b/src/hipscat_import/soap/run_soap.py
@@ -6,6 +6,7 @@ The actual logic of the map reduce is in the `map_reduce.py` file.
 from hipscat.io import file_io, write_metadata
 from tqdm import tqdm
 
+from hipscat_import.pipeline_resume_plan import PipelineResumePlan
 from hipscat_import.soap.arguments import SoapArguments
 from hipscat_import.soap.map_reduce import combine_partial_results, count_joins
 from hipscat_import.soap.resume_plan import SoapPlan
@@ -36,7 +37,9 @@ def run(args, client):
         resume_plan.wait_for_counting(futures)
 
     # All done - write out the metadata
-    with tqdm(total=4, desc="Finishing", disable=not args.progress_bar) as step_progress:
+    with tqdm(
+        total=4, desc=PipelineResumePlan.get_formatted_stage_name("Finishing"), disable=not args.progress_bar
+    ) as step_progress:
         # pylint: disable=duplicate-code
         # Very similar to /index/run_index.py
         combine_partial_results(args.tmp_path, args.catalog_path)

--- a/tests/hipscat_import/test_pipeline_resume_plan.py
+++ b/tests/hipscat_import/test_pipeline_resume_plan.py
@@ -74,3 +74,17 @@ def test_safe_to_resume(tmp_path):
     ## If there are no more intermediate files, we don't need to set resume.
     plan.clean_resume_files()
     plan.safe_to_resume()
+
+
+def test_formatted_stage_name():
+    formatted = PipelineResumePlan.get_formatted_stage_name(None)
+    assert formatted == "Progress  "
+
+    formatted = PipelineResumePlan.get_formatted_stage_name("")
+    assert formatted == "Progress  "
+
+    formatted = PipelineResumePlan.get_formatted_stage_name("stage")
+    assert formatted == "Stage     "
+
+    formatted = PipelineResumePlan.get_formatted_stage_name("very long stage name")
+    assert formatted == "Very long stage name"


### PR DESCRIPTION
## Change Description

Closes #125 

Uses consistent minimum length for tqdm description in pipeline stages.

This stops short of adding another wrapper around tqdm step progress initialization.