### PR TITLE
Add a tad more context for failure email.

### DIFF
--- a/src/hipscat_import/pipeline.py
+++ b/src/hipscat_import/pipeline.py
@@ -59,7 +59,11 @@ def _send_failure_email(args: RuntimeArguments, exception: Exception):
     message = EmailMessage()
     message["Subject"] = "hipscat-import failure."
     message["To"] = args.completion_email_address
-    message.set_content(f"failed with message:\n{exception}")
+    message.set_content(
+        f"output_catalog_name: {args.output_catalog_name}"
+        "\n\nSee logs for more details"
+        f"\n\nFailed with message:\n\n{exception}"
+    )
 
     _send_email(message)
 


### PR DESCRIPTION
## Change Description

Includes the catalog name in the failure email, to give some more hints about where to look for failure logs.