### PR TITLE
Pin pandas version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "healpy",
     "hipscat >= 0.1.2",
     "ipykernel", # Support for Jupyter notebooks
-    "pandas",
+    "pandas < 2.1.0",
     "pyarrow",
     "tqdm",
     "numpy < 1.25",


### PR DESCRIPTION
## Change Description

Pin pandas version to before 2.1.0, on the theory that the new version is causing smoke test failures.