### PR TITLE
Check for valid catalog directories.

### DIFF
--- a/src/hipscat_import/index/arguments.py
+++ b/src/hipscat_import/index/arguments.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 
 from hipscat.catalog import Catalog
 from hipscat.catalog.index.index_catalog_info import IndexCatalogInfo
+from hipscat.io.validation import is_valid_catalog
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -38,6 +39,8 @@ class IndexArguments(RuntimeArguments):
         if not self.include_hipscat_index and not self.include_order_pixel:
             raise ValueError("At least one of include_hipscat_index or include_order_pixel must be True")
 
+        if not is_valid_catalog(self.input_catalog_path):
+            raise ValueError("input_catalog_path not a valid catalog")
         self.input_catalog = Catalog.read_from_hipscat(catalog_path=self.input_catalog_path)
 
         if self.compute_partition_size < 100_000:

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -5,7 +5,7 @@ import healpy as hp
 import numpy as np
 from hipscat.catalog import Catalog
 from hipscat.catalog.margin_cache.margin_cache_catalog_info import MarginCacheCatalogInfo
-from hipscat.io import file_io
+from hipscat.io.validation import is_valid_catalog
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -33,8 +33,10 @@ class MarginCacheArguments(RuntimeArguments):
 
     def _check_arguments(self):
         super()._check_arguments()
-        if not file_io.does_file_or_directory_exist(self.input_catalog_path):
-            raise FileNotFoundError("input_catalog_path not found on local storage")
+        if not self.input_catalog_path:
+            raise ValueError("input_catalog_path is required")
+        if not is_valid_catalog(self.input_catalog_path):
+            raise ValueError("input_catalog_path not a valid catalog")
 
         self.catalog = Catalog.read_from_hipscat(self.input_catalog_path)
 

--- a/src/hipscat_import/soap/arguments.py
+++ b/src/hipscat_import/soap/arguments.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 
 from hipscat.catalog.association_catalog.association_catalog import AssociationCatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
+from hipscat.io.validation import is_valid_catalog
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -33,11 +34,15 @@ class SoapArguments(RuntimeArguments):
             raise ValueError("object_catalog_dir is required")
         if not self.object_id_column:
             raise ValueError("object_id_column is required")
+        if not is_valid_catalog(self.object_catalog_dir):
+            raise ValueError("object_catalog_dir not a valid catalog")
 
         if not self.source_catalog_dir:
             raise ValueError("source_catalog_dir is required")
         if not self.source_object_id_column:
             raise ValueError("source_object_id_column is required")
+        if not is_valid_catalog(self.source_catalog_dir):
+            raise ValueError("source_catalog_dir not a valid catalog")
 
         if self.compute_partition_size < 100_000:
             raise ValueError("compute_partition_size must be at least 100_000")

--- a/tests/hipscat_import/catalog/test_file_readers.py
+++ b/tests/hipscat_import/catalog/test_file_readers.py
@@ -33,6 +33,14 @@ def test_unknown_file_type():
         get_file_reader("unknown")
 
 
+def test_file_exists(small_sky_dir):
+    """File reader factory method should fail for missing files or directories"""
+    with pytest.raises(FileNotFoundError, match="File not found"):
+        next(CsvReader().read("foo_not_really_a_path"))
+    with pytest.raises(FileNotFoundError, match="Directory found at path"):
+        next(CsvReader().read(small_sky_dir))
+
+
 def test_csv_reader(small_sky_single_file):
     """Verify we can read the csv file into a single data frame."""
     total_chunks = 0

--- a/tests/hipscat_import/index/test_index_argument.py
+++ b/tests/hipscat_import/index/test_index_argument.py
@@ -22,6 +22,17 @@ def test_empty_required(tmp_path, small_sky_object_catalog):
             output_catalog_name="small_sky_object_index",
         )
 
+    ## Input path is bad
+    with pytest.raises(ValueError, match="input_catalog_path"):
+        IndexArguments(
+            input_catalog_path="/foo",
+            indexing_column="id",
+            output_path=tmp_path,
+            output_catalog_name="small_sky_object_index",
+            overwrite=True,
+        )
+
+    ## Indexing column is required.
     with pytest.raises(ValueError, match="indexing_column "):
         IndexArguments(
             input_catalog_path=small_sky_object_catalog,

--- a/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
@@ -11,11 +11,21 @@ from hipscat_import.margin_cache.margin_cache_arguments import MarginCacheArgume
 def test_empty_required(tmp_path):
     """*Most* required arguments are provided."""
     ## Input catalog path is missing
-    with pytest.raises(FileNotFoundError, match="input_catalog_path"):
+    with pytest.raises(ValueError, match="input_catalog_path"):
         MarginCacheArguments(
             margin_threshold=5.0,
             output_path=tmp_path,
             output_catalog_name="catalog_cache",
+        )
+
+    ## Input catalog path is bad
+    with pytest.raises(ValueError, match="input_catalog_path"):
+        MarginCacheArguments(
+            input_catalog_path="/foo",
+            margin_threshold=5.0,
+            output_path=tmp_path,
+            output_catalog_name="catalog_cache",
+            overwrite=True,
         )
 
 

--- a/tests/hipscat_import/soap/test_soap_arguments.py
+++ b/tests/hipscat_import/soap/test_soap_arguments.py
@@ -46,6 +46,35 @@ def test_empty_required(tmp_path, small_sky_object_catalog, small_sky_source_cat
             )
 
 
+def test_catalog_paths(tmp_path, small_sky_object_catalog, small_sky_source_catalog):
+    """*Most* required arguments are provided."""
+    ## Object catalog path is bad.
+    with pytest.raises(ValueError, match="object_catalog_dir"):
+        SoapArguments(
+            object_catalog_dir="/foo",
+            object_id_column="id",
+            source_catalog_dir=small_sky_source_catalog,
+            source_object_id_column="object_id",
+            output_catalog_name="small_sky_association",
+            output_path=tmp_path,
+            progress_bar=False,
+            overwrite=True,
+        )
+
+    ## Source catalog path is bad.
+    with pytest.raises(ValueError, match="source_catalog_dir"):
+        SoapArguments(
+            object_catalog_dir=small_sky_object_catalog,
+            object_id_column="id",
+            source_catalog_dir="/foo",
+            source_object_id_column="object_id",
+            output_catalog_name="small_sky_association",
+            output_path=tmp_path,
+            progress_bar=False,
+            overwrite=True,
+        )
+
+
 def test_compute_partition_size(tmp_path, small_sky_object_catalog, small_sky_source_catalog):
     """Test validation of compute_partition_size."""
     with pytest.raises(ValueError, match="compute_partition_size"):


### PR DESCRIPTION
## Change Description

Uses new `hipscat.io.validation.is_valid_catalog` to check for basic catalog existence/validity for catalogs that are used for inputs to other import pipelines.

Note that the smoke test is currently failing after the release of the above method. This PR aims to address the failing test, as well as augment existing passing checks.

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation