### PR TITLE
add the negative tree pixels to margin cache pipeline

### DIFF
--- a/src/hipscat_import/margin_cache/margin_cache.py
+++ b/src/hipscat_import/margin_cache/margin_cache.py
@@ -107,9 +107,14 @@ def generate_margin_cache(args, client):
     # determine which order to generate margin pixels for
     partition_stats = args.catalog.partition_info.get_healpix_pixels()
 
-    margin_pairs = _find_partition_margin_pixel_pairs(partition_stats, args.margin_order)
+    # get the negative tree pixels
+    negative_pixels = args.catalog.generate_negative_tree_pixels()
 
-    _create_margin_directory(partition_stats, args.catalog_path)
+    combined_pixels = partition_stats + negative_pixels
+
+    margin_pairs = _find_partition_margin_pixel_pairs(combined_pixels, args.margin_order)
+
+    _create_margin_directory(combined_pixels, args.catalog_path)
 
     _map_to_margin_shards(
         client=client,
@@ -118,4 +123,4 @@ def generate_margin_cache(args, client):
         margin_pairs=margin_pairs,
     )
 
-    _reduce_margin_shards(client=client, args=args, partition_pixels=partition_stats)
+    _reduce_margin_shards(client=client, args=args, partition_pixels=combined_pixels)

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -26,8 +26,6 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
 
     mc.generate_margin_cache(args, dask_client)
 
-    print(args.catalog.partition_info.get_healpix_pixels())
-
     norder = 1
     npix = 47
 
@@ -36,6 +34,30 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
     data = pd.read_parquet(test_file)
 
     assert len(data) == 13
+
+@pytest.mark.dask(timeout=150)
+def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, dask_client):
+    """Test that margin cache generation works end to end."""
+    args = MarginCacheArguments(
+        margin_threshold=36000.0,
+        input_catalog_path=small_sky_source_catalog,
+        output_path=tmp_path,
+        output_catalog_name="catalog_cache",
+        margin_order=4,
+    )
+
+    assert args.catalog.catalog_info.ra_column == "source_ra"
+
+    mc.generate_margin_cache(args, dask_client)
+
+    norder = 0
+    npix = 7
+
+    negative_test_file = paths.pixel_catalog_file(args.catalog_path, norder, npix)
+
+    negative_data = pd.read_parquet(negative_test_file)
+
+    assert len(negative_data) > 0
 
 
 def test_partition_margin_pixel_pairs(small_sky_source_catalog, tmp_path):

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -37,7 +37,7 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
 
 @pytest.mark.dask(timeout=150)
 def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, dask_client):
-    """Test that margin cache generation works end to end."""
+    """Test that margin cache generation can generate a file for a negative pixel."""
     args = MarginCacheArguments(
         margin_threshold=36000.0,
         input_catalog_path=small_sky_source_catalog,
@@ -61,6 +61,7 @@ def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, da
 
 
 def test_partition_margin_pixel_pairs(small_sky_source_catalog, tmp_path):
+    """Ensure partition_margin_pixel_pairs can generate main partition pixels."""
     args = MarginCacheArguments(
         margin_threshold=5.0,
         input_catalog_path=small_sky_source_catalog,
@@ -77,8 +78,34 @@ def test_partition_margin_pixel_pairs(small_sky_source_catalog, tmp_path):
     npt.assert_array_equal(margin_pairs.iloc[:10]["margin_pixel"], expected)
     assert len(margin_pairs) == 196
 
+def test_partition_margin_pixel_pairs_negative(small_sky_source_catalog, tmp_path):
+    """Ensure partition_margin_pixel_pairs can generate negative tree pixels."""
+    args = MarginCacheArguments(
+        margin_threshold=5.0,
+        input_catalog_path=small_sky_source_catalog,
+        output_path=tmp_path,
+        output_catalog_name="catalog_cache",
+    )
+
+    partition_stats = args.catalog.partition_info.get_healpix_pixels()
+    negative_pixels = args.catalog.generate_negative_tree_pixels()
+    combined_pixels = partition_stats + negative_pixels
+
+    margin_pairs = mc._find_partition_margin_pixel_pairs(
+        combined_pixels, args.margin_order
+    )
+
+    expected_order = 0
+    expected_pixel = 10
+    expected = np.array([490, 704, 712, 736, 744, 706, 714, 738, 746, 512])
+
+    assert margin_pairs.iloc[-1]["partition_order"] == expected_order
+    assert margin_pairs.iloc[-1]["partition_pixel"] == expected_pixel
+    npt.assert_array_equal(margin_pairs.iloc[-10:]["margin_pixel"], expected)
+    assert len(margin_pairs) == 536
 
 def test_create_margin_directory(small_sky_source_catalog, tmp_path):
+    """Ensure create_margin_directory works on main partition_pixels"""
     args = MarginCacheArguments(
         margin_threshold=5.0,
         input_catalog_path=small_sky_source_catalog,


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
- [x] My PR includes a link to the issue that I am addressing

mixes in the negative tree pixels into the margin cache pipeline when appropriate (every step except for the mapping stage) to allow for full coverage.

resolves #137 .



## Solution Description
<!-- Please explain the technical solution that I have provided and how it addresses the issue or feature being implemented -->

- calls `Catalog.generate_negative_tree_pixels()` and combines them with `partition_stats`.
- also creates a new test specifically to ensure that margin caching can create a pixel file for a zero data pixel (i.e. one that's not represented in the main catalog partitions).

## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible).
