### PR TITLE
Remove get_pixels calls

### DIFF
--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -26,6 +26,7 @@ class ResumePlan(PipelineResumePlan):
     split_keys: List[Tuple[str, str]] = field(default_factory=list)
     """set of files (and job keys) that have yet to be split"""
     destination_pixel_map: Optional[List[Tuple[HealpixPixel, List[HealpixPixel], str]]] = None
+    """Fully resolved map of destination pixels to constituent smaller pixels"""
 
     MAPPING_STAGE = "mapping"
     SPLITTING_STAGE = "splitting"
@@ -152,7 +153,7 @@ class ResumePlan(PipelineResumePlan):
         # - remove all partial histograms
         remaining_map_files = self.get_remaining_map_keys()
         if len(remaining_map_files) > 0:
-            raise RuntimeError("some map stages did not complete successfully.")
+            raise RuntimeError(f"{len(remaining_map_files)} map stages did not complete successfully.")
         histogram_files = file_io.find_files_matching_path(self.tmp_path, self.HISTOGRAMS_DIR, "**.binary")
         for file_name in histogram_files:
             with open(file_name, "rb") as file_handle:
@@ -236,7 +237,7 @@ class ResumePlan(PipelineResumePlan):
         self.wait_for_futures(futures, self.SPLITTING_STAGE)
         remaining_split_items = self.get_remaining_split_keys()
         if len(remaining_split_items) > 0:
-            raise RuntimeError("some split stages did not complete successfully.")
+            raise RuntimeError(f"{len(remaining_split_items)} split stages did not complete successfully.")
         self.touch_stage_done_file(self.SPLITTING_STAGE)
 
     def is_splitting_done(self) -> bool:
@@ -276,5 +277,5 @@ class ResumePlan(PipelineResumePlan):
         self.wait_for_futures(futures, self.REDUCING_STAGE)
         remaining_reduce_items = self.get_reduce_items()
         if len(remaining_reduce_items) > 0:
-            raise RuntimeError("some reduce stages did not complete successfully.")
+            raise RuntimeError(f"{len(remaining_reduce_items)} reduce stages did not complete successfully.")
         self.touch_stage_done_file(self.REDUCING_STAGE)

--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Tuple
 import numpy as np
 from hipscat import pixel_math
 from hipscat.io import FilePointer, file_io
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from numpy import frombuffer
 from tqdm import tqdm
 
@@ -24,7 +25,7 @@ class ResumePlan(PipelineResumePlan):
     """list of files (and job keys) that have yet to be mapped"""
     split_keys: List[Tuple[str, str]] = field(default_factory=list)
     """set of files (and job keys) that have yet to be split"""
-    destination_pixel_map: Optional[np.array] = None
+    destination_pixel_map: Optional[List[Tuple[HealpixPixel, List[HealpixPixel], str]]] = None
 
     MAPPING_STAGE = "mapping"
     SPLITTING_STAGE = "splitting"

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -40,8 +40,7 @@ class MarginCacheArguments(RuntimeArguments):
 
         self.catalog = Catalog.read_from_hipscat(self.input_catalog_path)
 
-        partition_stats = self.catalog.get_pixels()
-        highest_order = np.max(partition_stats["Norder"].values)
+        highest_order = self.catalog.partition_info.get_highest_order()
         margin_pixel_k = highest_order + 1
         if self.margin_order > -1:
             if self.margin_order < margin_pixel_k:

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -2,7 +2,6 @@ import warnings
 from dataclasses import dataclass
 
 import healpy as hp
-import numpy as np
 from hipscat.catalog import Catalog
 from hipscat.catalog.margin_cache.margin_cache_catalog_info import MarginCacheCatalogInfo
 from hipscat.io.validation import is_valid_catalog

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -113,12 +113,13 @@ class PipelineResumePlan:
     def wait_for_futures(self, futures, stage_name):
         """Wait for collected futures to complete.
 
-        As each future completes, read the task key and write to the log file.
-        If all tasks complete successfully, touch the done file. Otherwise, raise an error.
+        As each future completes, check the returned status.
 
         Args:
             futures(List[future]): collected futures
             stage_name(str): name of the stage (e.g. mapping, reducing)
+        Raises:
+            RuntimeError if any future returns an error status.
         """
         some_error = False
         formatted_stage_name = self.get_formatted_stage_name(stage_name)
@@ -128,11 +129,10 @@ class PipelineResumePlan:
             total=len(futures),
             disable=(not self.progress_bar),
         ):
-            if future.status == "error":  # pragma: no cover
+            if future.status == "error":
                 some_error = True
-        if some_error:  # pragma: no cover
+        if some_error:
             raise RuntimeError(f"Some {stage_name} stages failed. See logs for details.")
-        self.touch_stage_done_file(stage_name)
 
     @staticmethod
     def get_formatted_stage_name(stage_name) -> str:

--- a/src/hipscat_import/soap/resume_plan.py
+++ b/src/hipscat_import/soap/resume_plan.py
@@ -62,6 +62,7 @@ class SoapPlan(PipelineResumePlan):
     def wait_for_counting(self, futures):
         """Wait for counting stage futures to complete."""
         self.wait_for_futures(futures, self.COUNTING_STAGE)
+        self.touch_stage_done_file(self.COUNTING_STAGE)
 
     def is_counting_done(self) -> bool:
         """Are there sources left to count?"""

--- a/src/hipscat_import/soap/resume_plan.py
+++ b/src/hipscat_import/soap/resume_plan.py
@@ -89,7 +89,7 @@ class SoapPlan(PipelineResumePlan):
         elif self.source_pixel_map is None:
             self.source_pixel_map = source_pixel_map
         if self.source_pixel_map is None:
-            raise RuntimeError("source_pixel_map not provided for progress tracking.")
+            raise ValueError("source_pixel_map not provided for progress tracking.")
 
         counted_keys = set(self.get_keys_from_file_names(self.tmp_path, ".csv"))
         return [

--- a/tests/hipscat_import/catalog/test_resume_plan.py
+++ b/tests/hipscat_import/catalog/test_resume_plan.py
@@ -3,6 +3,7 @@
 import hipscat.pixel_math as hist
 import numpy.testing as npt
 import pytest
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 from hipscat_import.catalog.resume_plan import ResumePlan
 
@@ -92,30 +93,50 @@ def test_same_input_paths(tmp_path, small_sky_single_file, formats_headers_csv):
 
 def test_read_write_histogram(tmp_path):
     """Test that we can read what we write into a histogram file."""
-    plan = ResumePlan(tmp_path=tmp_path, progress_bar=False)
+    plan = ResumePlan(tmp_path=tmp_path, progress_bar=False, input_paths=["foo1"])
+
+    ## We're not ready to read the final histogram - missing partial histograms.
+    with pytest.raises(RuntimeError, match="map stages"):
+        result = plan.read_histogram(0)
+
+    expected = hist.empty_histogram(0)
+    expected[11] = 131
+
+    remaining_keys = plan.get_remaining_map_keys()
+    assert remaining_keys == [("map_0", "foo1")]
+
+    ResumePlan.write_partial_histogram(tmp_path=tmp_path, mapping_key="map_0", histogram=expected)
+
+    remaining_keys = plan.get_remaining_map_keys()
+    assert len(remaining_keys) == 0
+    result = plan.read_histogram(0)
+    npt.assert_array_equal(result, expected)
+
+
+def error_on_even(argument):
+    """Silly little method used to test futures that fail under predictable conditions"""
+    if argument % 2 == 0:
+        raise RuntimeError("we are at odds with evens")
+
+
+@pytest.mark.dask
+def test_some_map_task_failures(tmp_path, dask_client):
+    """Test that we only consider map stage successful if all partial files are written"""
+    plan = ResumePlan(tmp_path=tmp_path, progress_bar=False, input_paths=["foo1"])
+
+    ## Method doesn't FAIL, but it doesn't write out the partial histogram either.
+    futures = [dask_client.submit(error_on_even, 1)]
+    with pytest.raises(RuntimeError, match="map stages"):
+        plan.wait_for_mapping(futures)
 
     expected = hist.empty_histogram(0)
     expected[11] = 131
 
     ResumePlan.write_partial_histogram(tmp_path=tmp_path, mapping_key="map_0", histogram=expected)
 
-    keys = plan.get_mapping_keys_from_histograms()
-    assert keys == ["map_0"]
-    result = plan.read_histogram(0)
-    npt.assert_array_equal(result, expected)
-
-    keys = plan.get_mapping_keys_from_histograms()
-    assert len(keys) == 0
-
-    plan.clean_resume_files()
-
-    plan = ResumePlan(tmp_path=tmp_path, progress_bar=False)
-    empty = hist.empty_histogram(0)
-    result = plan.read_histogram(0)
-    npt.assert_array_equal(result, empty)
-
-    keys = plan.get_mapping_keys_from_histograms()
-    assert len(keys) == 0
+    ## Method succeeds, and partial histogram is present.
+    futures = [dask_client.submit(error_on_even, 1)]
+    plan.wait_for_mapping(futures)
 
 
 def test_read_write_splitting_keys(tmp_path, small_sky_single_file, formats_headers_csv):
@@ -141,3 +162,57 @@ def test_read_write_splitting_keys(tmp_path, small_sky_single_file, formats_head
     plan.gather_plan()
     split_keys = plan.split_keys
     assert len(split_keys) == 2
+
+
+@pytest.mark.dask
+def test_some_split_task_failures(tmp_path, dask_client):
+    """Test that we only consider split stage successful if all done files are written"""
+    plan = ResumePlan(tmp_path=tmp_path, progress_bar=False, input_paths=["foo1"])
+
+    ## Method doesn't FAIL, but it doesn't write out the done file either.
+    futures = [dask_client.submit(error_on_even, 1)]
+    with pytest.raises(RuntimeError, match="split stages"):
+        plan.wait_for_splitting(futures)
+
+    ResumePlan.touch_key_done_file(tmp_path, ResumePlan.SPLITTING_STAGE, "split_0")
+
+    ## Method succeeds, and done file is present.
+    futures = [dask_client.submit(error_on_even, 1)]
+    plan.wait_for_splitting(futures)
+
+
+def test_get_reduce_items(tmp_path):
+    """Test generation of remaining reduce items"""
+    destination_pixel_map = {HealpixPixel(0, 11): (131, [44, 45, 46])}
+    plan = ResumePlan(tmp_path=tmp_path, progress_bar=False)
+
+    with pytest.raises(RuntimeError, match="destination pixel map"):
+        remaining_reduce_items = plan.get_reduce_items()
+
+    remaining_reduce_items = plan.get_reduce_items(destination_pixel_map=destination_pixel_map)
+    assert len(remaining_reduce_items) == 1
+
+    ResumePlan.reducing_key_done(tmp_path=tmp_path, reducing_key="0_11")
+    remaining_reduce_items = plan.get_reduce_items(destination_pixel_map=destination_pixel_map)
+    assert len(remaining_reduce_items) == 0
+
+
+@pytest.mark.dask
+def test_some_reduce_task_failures(tmp_path, dask_client):
+    """Test that we only consider reduce stage successful if all done files are written"""
+    plan = ResumePlan(tmp_path=tmp_path, progress_bar=False)
+
+    destination_pixel_map = {HealpixPixel(0, 11): (131, [44, 45, 46])}
+    remaining_reduce_items = plan.get_reduce_items(destination_pixel_map=destination_pixel_map)
+    assert len(remaining_reduce_items) == 1
+
+    ## Method doesn't FAIL, but it doesn't write out the done file either.
+    futures = [dask_client.submit(error_on_even, 1)]
+    with pytest.raises(RuntimeError, match="reduce stages"):
+        plan.wait_for_reducing(futures)
+
+    ResumePlan.touch_key_done_file(tmp_path, ResumePlan.REDUCING_STAGE, "0_11")
+
+    ## Method succeeds, and done file is present.
+    futures = [dask_client.submit(error_on_even, 1)]
+    plan.wait_for_reducing(futures)

--- a/tests/hipscat_import/catalog/test_run_import.py
+++ b/tests/hipscat_import/catalog/test_run_import.py
@@ -82,7 +82,7 @@ def test_resume_dask_runner(
     assert catalog.catalog_info.ra_column == "ra"
     assert catalog.catalog_info.dec_column == "dec"
     assert catalog.catalog_info.total_rows == 131
-    assert len(catalog.get_pixels()) == 1
+    assert len(catalog.get_healpix_pixels()) == 1
 
     # Check that the catalog parquet file exists and contains correct object IDs
     output_file = os.path.join(args.catalog_path, "Norder=0", "Dir=0", "Npix=11.parquet")
@@ -122,7 +122,7 @@ def test_resume_dask_runner(
     assert catalog.catalog_info.ra_column == "ra"
     assert catalog.catalog_info.dec_column == "dec"
     assert catalog.catalog_info.total_rows == 131
-    assert len(catalog.get_pixels()) == 1
+    assert len(catalog.get_healpix_pixels()) == 1
     assert_parquet_file_ids(output_file, "id", expected_ids)
 
 
@@ -153,7 +153,7 @@ def test_dask_runner(
     assert catalog.catalog_info.ra_column == "ra"
     assert catalog.catalog_info.dec_column == "dec"
     assert catalog.catalog_info.total_rows == 131
-    assert len(catalog.get_pixels()) == 1
+    assert len(catalog.get_healpix_pixels()) == 1
 
     # Check that the catalog parquet file exists and contains correct object IDs
     output_file = os.path.join(args.catalog_path, "Norder=0", "Dir=0", "Npix=11.parquet")

--- a/tests/hipscat_import/catalog/test_run_round_trip.py
+++ b/tests/hipscat_import/catalog/test_run_round_trip.py
@@ -5,6 +5,7 @@ regression the test case is exercising.
 """
 
 
+import glob
 import os
 
 import numpy as np
@@ -321,8 +322,6 @@ def test_import_starr_file(
         """Shallow subclass"""
 
         def read(self, input_file):
-            import glob
-
             files = glob.glob(f"{input_file}/**.starr")
             files.sort()
             for file in files:

--- a/tests/hipscat_import/catalog/test_run_round_trip.py
+++ b/tests/hipscat_import/catalog/test_run_round_trip.py
@@ -52,7 +52,7 @@ def test_import_source_table(
     assert catalog.catalog_path == args.catalog_path
     assert catalog.catalog_info.ra_column == "source_ra"
     assert catalog.catalog_info.dec_column == "source_dec"
-    assert len(catalog.get_pixels()) == 14
+    assert len(catalog.get_healpix_pixels()) == 14
 
 
 @pytest.mark.dask
@@ -347,7 +347,7 @@ def test_import_starr_file(
     assert catalog.on_disk
     assert catalog.catalog_path == args.catalog_path
     assert catalog.catalog_info.total_rows == 131
-    assert len(catalog.get_pixels()) == 1
+    assert len(catalog.get_healpix_pixels()) == 1
 
     # Check that the catalog parquet file exists and contains correct object IDs
     output_file = os.path.join(args.catalog_path, "Norder=0", "Dir=0", "Npix=11.parquet")

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -35,6 +35,7 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
 
     assert len(data) == 13
 
+
 @pytest.mark.dask(timeout=150)
 def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, dask_client):
     """Test that margin cache generation can generate a file for a negative pixel."""
@@ -78,6 +79,7 @@ def test_partition_margin_pixel_pairs(small_sky_source_catalog, tmp_path):
     npt.assert_array_equal(margin_pairs.iloc[:10]["margin_pixel"], expected)
     assert len(margin_pairs) == 196
 
+
 def test_partition_margin_pixel_pairs_negative(small_sky_source_catalog, tmp_path):
     """Ensure partition_margin_pixel_pairs can generate negative tree pixels."""
     args = MarginCacheArguments(
@@ -91,9 +93,7 @@ def test_partition_margin_pixel_pairs_negative(small_sky_source_catalog, tmp_pat
     negative_pixels = args.catalog.generate_negative_tree_pixels()
     combined_pixels = partition_stats + negative_pixels
 
-    margin_pairs = mc._find_partition_margin_pixel_pairs(
-        combined_pixels, args.margin_order
-    )
+    margin_pairs = mc._find_partition_margin_pixel_pairs(combined_pixels, args.margin_order)
 
     expected_order = 0
     expected_pixel = 10
@@ -103,6 +103,7 @@ def test_partition_margin_pixel_pairs_negative(small_sky_source_catalog, tmp_pat
     assert margin_pairs.iloc[-1]["partition_pixel"] == expected_pixel
     npt.assert_array_equal(margin_pairs.iloc[-10:]["margin_pixel"], expected)
     assert len(margin_pairs) == 536
+
 
 def test_create_margin_directory(small_sky_source_catalog, tmp_path):
     """Ensure create_margin_directory works on main partition_pixels"""

--- a/tests/hipscat_import/soap/test_soap_resume_plan.py
+++ b/tests/hipscat_import/soap/test_soap_resume_plan.py
@@ -119,6 +119,27 @@ def test_cached_map_file(small_sky_soap_args):
     assert len(plan.count_keys) == 14
 
 
+def test_get_sources_to_count(small_sky_soap_args):
+    """Test generation of remaining count items"""
+    source_pixel_map = {HealpixPixel(0, 11): (131, [44, 45, 46])}
+    plan = SoapPlan(small_sky_soap_args)
+
+    ## Kind of silly, but clear out the pixel map, since it's populated on init.
+    ## Fail to find the remaining sources to count because we don't know the map.
+    plan.source_pixel_map = None
+    with pytest.raises(ValueError, match="source_pixel_map"):
+        remaining_count_items = plan.get_sources_to_count()
+
+    ## Can now successfully find sources to count.
+    remaining_count_items = plan.get_sources_to_count(source_pixel_map=source_pixel_map)
+    assert len(remaining_count_items) == 1
+
+    ## Use previous value of sources map, and find intermediate file, so there are no 
+    ## remaining sources to count.
+    Path(small_sky_soap_args.tmp_path, "0_11.csv").touch()
+    remaining_count_items = plan.get_sources_to_count()
+    assert len(remaining_count_items) == 0
+
 def never_fails():
     """Method never fails, but never marks intermediate success file."""
     return

--- a/tests/hipscat_import/soap/test_soap_resume_plan.py
+++ b/tests/hipscat_import/soap/test_soap_resume_plan.py
@@ -134,11 +134,12 @@ def test_get_sources_to_count(small_sky_soap_args):
     remaining_count_items = plan.get_sources_to_count(source_pixel_map=source_pixel_map)
     assert len(remaining_count_items) == 1
 
-    ## Use previous value of sources map, and find intermediate file, so there are no 
+    ## Use previous value of sources map, and find intermediate file, so there are no
     ## remaining sources to count.
     Path(small_sky_soap_args.tmp_path, "0_11.csv").touch()
     remaining_count_items = plan.get_sources_to_count()
     assert len(remaining_count_items) == 0
+
 
 def never_fails():
     """Method never fails, but never marks intermediate success file."""


### PR DESCRIPTION
## Change Description

In preparation for addressing https://github.com/astronomy-commons/hipscat/issues/142, this removes the `get_pixels` method in favor of `get_healpix_pixels` method to mirror what will be available on the `Catalog` API.