### PR TITLE
Set lower default import order.

### DIFF
--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -54,7 +54,7 @@ class ImportArguments(RuntimeArguments):
     """healpix order to use when mapping. if this is
     a positive number, this will be the order of all final pixels and we
     will not combine pixels according to the threshold"""
-    highest_healpix_order: int = 10
+    highest_healpix_order: int = 7
     """healpix order to use when mapping. this will
     not necessarily be the order used in the final catalog, as we may combine
     pixels that don't meed the threshold"""


### PR DESCRIPTION
Set the default `highest_healpix_order` parameter lower. This reduces the intermediate storage, and speeds most operations. For importing larger, denser catalogs, this will need to be overridden to a larger value, but for the majority of catalogs right now, 7 is sufficient.