### PR TITLE
Add a partition_info on SOAP results.

### DIFF
--- a/src/hipscat_import/soap/map_reduce.py
+++ b/src/hipscat_import/soap/map_reduce.py
@@ -125,3 +125,10 @@ def combine_partial_results(input_path, output_path):
             file_pointer=file_io.append_paths_to_pointer(output_path, "unmatched_sources.csv"),
             index=False,
         )
+
+    primary_only = matched.groupby(["Norder", "Dir", "Npix"])["num_rows"].sum().reset_index()
+    file_io.write_dataframe_to_csv(
+        dataframe=primary_only,
+        file_pointer=file_io.append_paths_to_pointer(output_path, "partition_info.csv"),
+        index=False,
+    )


### PR DESCRIPTION
## Change Description

This is a little silly. Even though we'd like to remove `partition_info.csv` and `partition_join_info.csv`, they're required with the most recent version of the hipscat `Dataset` class. We need to be a valid dataset so we can release a new version of the hipscat library and still pass builds here.