### PR TITLE
Create output directory

### DIFF
--- a/src/hipscat_import/runtime_arguments.py
+++ b/src/hipscat_import/runtime_arguments.py
@@ -65,9 +65,6 @@ class RuntimeArguments:
         if self.dask_threads_per_worker <= 0:
             raise ValueError("dask_threads_per_worker should be greater than 0")
 
-        if not file_io.does_file_or_directory_exist(self.output_path):
-            raise FileNotFoundError(f"output_path ({self.output_path}) not found on local storage")
-
         self.catalog_path = file_io.append_paths_to_pointer(self.output_path, self.output_catalog_name)
         if not self.overwrite:
             if file_io.directory_has_contents(self.catalog_path):

--- a/src/hipscat_import/verification/arguments.py
+++ b/src/hipscat_import/verification/arguments.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass, field
 from typing import List, Optional
 
 from hipscat.catalog import Catalog
+from hipscat.io.validation import is_valid_catalog
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -32,6 +33,8 @@ class VerificationArguments(RuntimeArguments):
         if not self.input_catalog_path and not self.input_catalog:
             raise ValueError("input catalog is required (either input_catalog_path or input_catalog)")
         if not self.input_catalog:
+            if not is_valid_catalog(self.input_catalog_path):
+                raise ValueError("input_catalog_path not a valid catalog")
             self.input_catalog = Catalog.read_from_hipscat(catalog_path=self.input_catalog_path)
         if not self.input_catalog_path:
             self.input_catalog_path = self.input_catalog.catalog_path

--- a/tests/hipscat_import/index/test_index_argument.py
+++ b/tests/hipscat_import/index/test_index_argument.py
@@ -52,25 +52,14 @@ def test_invalid_paths(tmp_path, small_sky_object_catalog):
         output_path=tmp_path,
         output_catalog_name="small_sky_object_index",
     )
-
-    ## Bad input path
-    with pytest.raises(FileNotFoundError):
+    ## Input path is invalid catalog
+    with pytest.raises(ValueError):
         IndexArguments(
             input_catalog_path="path",
             indexing_column="id",
-            output_path="path",
+            output_path=tmp_path,
             output_catalog_name="small_sky_object_index",
         )
-
-    ## Input path has no files
-    with pytest.raises(FileNotFoundError):
-        IndexArguments(
-            input_catalog_path="path",
-            indexing_column="id",
-            output_path="path",
-            output_catalog_name="small_sky_object_index",
-        )
-
 
 def test_good_paths(tmp_path, small_sky_object_catalog):
     """Required arguments are provided, and paths are found."""

--- a/tests/hipscat_import/index/test_index_argument.py
+++ b/tests/hipscat_import/index/test_index_argument.py
@@ -53,13 +53,14 @@ def test_invalid_paths(tmp_path, small_sky_object_catalog):
         output_catalog_name="small_sky_object_index",
     )
     ## Input path is invalid catalog
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="input_catalog_path not a valid catalog"):
         IndexArguments(
             input_catalog_path="path",
             indexing_column="id",
-            output_path=tmp_path,
+            output_path=f"{tmp_path}/path",
             output_catalog_name="small_sky_object_index",
         )
+
 
 def test_good_paths(tmp_path, small_sky_object_catalog):
     """Required arguments are provided, and paths are found."""

--- a/tests/hipscat_import/test_runtime_arguments.py
+++ b/tests/hipscat_import/test_runtime_arguments.py
@@ -49,13 +49,6 @@ def test_catalog_name(tmp_path):
 
 def test_invalid_paths(tmp_path):
     """Required arguments are provided, but paths aren't found."""
-    ## Bad output path
-    with pytest.raises(FileNotFoundError):
-        RuntimeArguments(
-            output_catalog_name="catalog",
-            output_path="/foo/path",
-        )
-
     ## Bad temp path
     with pytest.raises(FileNotFoundError):
         RuntimeArguments(output_catalog_name="catalog", output_path=tmp_path, tmp_dir="/foo/path")

--- a/tests/hipscat_import/verification/test_verification_arguments.py
+++ b/tests/hipscat_import/verification/test_verification_arguments.py
@@ -1,6 +1,5 @@
 """Tests of argument validation"""
 
-
 import pytest
 from hipscat.catalog import Catalog
 
@@ -32,11 +31,11 @@ def test_invalid_paths(tmp_path, small_sky_object_catalog):
         output_catalog_name="small_sky_object_verification_report",
     )
 
-    ## Bad input path
-    with pytest.raises(FileNotFoundError):
+    ## Input path is invalid catalog
+    with pytest.raises(ValueError):
         VerificationArguments(
             input_catalog_path="path",
-            output_path="path",
+            output_path=tmp_path,
             output_catalog_name="small_sky_object_verification_report",
         )
 

--- a/tests/hipscat_import/verification/test_verification_arguments.py
+++ b/tests/hipscat_import/verification/test_verification_arguments.py
@@ -32,10 +32,10 @@ def test_invalid_paths(tmp_path, small_sky_object_catalog):
     )
 
     ## Input path is invalid catalog
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="input_catalog_path not a valid catalog"):
         VerificationArguments(
             input_catalog_path="path",
-            output_path=tmp_path,
+            output_path=f"{tmp_path}/path",
             output_catalog_name="small_sky_object_verification_report",
         )
 


### PR DESCRIPTION
Removes the check for the existence of the output directory when creating the runtime arguments, allowing for the full `catalog_path` to be created even if the base `output_path` does not exist. Closes #140.

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation
