### PR TITLE
Argument renaming

### DIFF
--- a/docs/catalogs/arguments.rst
+++ b/docs/catalogs/arguments.rst
@@ -10,12 +10,12 @@ will look something like:
 .. code-block:: python
 
     args = ImportArguments(
-        id_column="ObjectID",
+        sort_columns="ObjectID",
         ra_column="ObjectRA",
         dec_column="ObjectDec",
         input_path="./my_data",
         input_format="csv",
-        output_catalog_name="test_cat",
+        output_artifact_name="test_cat",
         output_path="./output",
     )
 
@@ -164,11 +164,11 @@ for either pipeline success or failure.
 Output
 -------------------------------------------------------------------------------
 
-You must specify a name for the catalog, using ``output_catalog_name``.
+You must specify a name for the catalog, using ``output_artifact_name``.
 
 You must specify where you want your catalog data to be written, using
 ``output_path``. This path should be the base directory for your catalogs, as 
-the full path for the catalog will take the form of ``output_path/output_catalog_name``.
+the full path for the catalog will take the form of ``output_path/output_artifact_name``.
 
 If there is already catalog data in the indicated directory, you can force a 
 new catalog to be written in the directory with the ``overwrite`` flag. 

--- a/docs/catalogs/public/allwise.rst
+++ b/docs/catalogs/public/allwise.rst
@@ -41,7 +41,7 @@ Example import
     type_map = dict(zip(type_frame["name"], type_frame["type"]))
 
     args = ImportArguments(
-        output_catalog_name="allwise",
+        output_artifact_name="allwise",
         input_path="/path/to/allwise/",
         input_format="csv.bz2",
         file_reader=CsvReader(
@@ -54,7 +54,7 @@ Example import
         use_schema_file="allwise_schema.parquet",
         ra_column="ra",
         dec_column="dec",
-        id_column="source_id",
+        sort_columns="source_id",
         pixel_threshold=1_000_000,
         highest_healpix_order=7,
         output_path="/path/to/catalogs/",

--- a/docs/catalogs/public/neowise.rst
+++ b/docs/catalogs/public/neowise.rst
@@ -41,7 +41,7 @@ Example import
     type_map = dict(zip(type_frame["name"], type_frame["type"]))
 
     args = ImportArguments(
-        output_catalog_name="neowise_1",
+        output_artifact_name="neowise_1",
         input_path="/path/to/neowiser_year8/",
         input_format="csv.bz2",
         file_reader=CsvReader(
@@ -56,7 +56,7 @@ Example import
         pixel_threshold=2_000_000,
         highest_healpix_order=9,
         use_schema_file="neowise_schema.parquet",
-        id_column="SOURCE_ID",
+        sort_columns="SOURCE_ID",
         output_path="/path/to/catalogs/",
     )
     runner.run(args)

--- a/docs/catalogs/public/panstarrs.rst
+++ b/docs/catalogs/public/panstarrs.rst
@@ -40,7 +40,7 @@ Example import of objects (otmo)
     in_file_paths = glob.glob("/path/to/otmo/OTMO_**.csv")
     in_file_paths.sort()
     args = ImportArguments(
-        output_catalog_name="ps1_otmo",
+        output_artifact_name="ps1_otmo",
         input_file_list=in_file_paths,
         input_format="csv",
         file_reader=CsvReader(
@@ -53,7 +53,7 @@ Example import of objects (otmo)
         ),
         ra_column="raMean",
         dec_column="decMean",
-        id_column="objID",
+        sort_columns="objID",
     )
     runner.pipeline(args)
 
@@ -71,7 +71,7 @@ Example import of detections
     in_file_paths = glob.glob("/path/to/detection/detection**.csv")
     in_file_paths.sort()
     args = ImportArguments(
-        output_catalog_name="ps1_detection",
+        output_artifact_name="ps1_detection",
         input_file_list=in_file_paths,
         input_format="csv",
         file_reader=CsvReader(
@@ -84,6 +84,6 @@ Example import of detections
         ),
         ra_column="ra",
         dec_column="dec",
-        id_column="objID",
+        sort_columns="objID",
     )
     runner.pipeline(args)

--- a/docs/catalogs/public/sdss.rst
+++ b/docs/catalogs/public/sdss.rst
@@ -68,12 +68,12 @@ Example import
     import hipscat_import.pipeline as runner
 
     args = ImportArguments(
-        output_catalog_name="sdss_dr16q",
+        output_artifact_name="sdss_dr16q",
         input_path="/data/sdss/parquet/",
         input_format="parquet",
         ra_column="RA",
         dec_column="DEC",
-        id_column="ID",
+        sort_columns="ID",
         pixel_threshold=1_000_000,
         highest_healpix_order=7,
         output_path="/path/to/catalogs/",

--- a/docs/catalogs/public/tic.rst
+++ b/docs/catalogs/public/tic.rst
@@ -38,7 +38,7 @@ Example import
     type_map = dict(zip(type_frame["name"], type_frame["type"]))
     
     args = ImportArguments(
-        output_catalog_name="tic_1",
+        output_artifact_name="tic_1",
         input_path="/path/to/tic/",
         input_format="csv.gz",
         file_reader=CsvReader(
@@ -49,7 +49,7 @@ Example import
         ).read,
         ra_column="ra",
         dec_column="dec",
-        id_column="ID",
+        sort_columns="ID",
         output_path="/path/to/catalogs/",
         use_schema_file="tic_schema.parquet",
     )

--- a/docs/catalogs/public/zubercal.rst
+++ b/docs/catalogs/public/zubercal.rst
@@ -76,7 +76,7 @@ Challenges with this data set
     files.sort()
 
     args = ImportArguments(
-        output_catalog_name="zubercal",
+        output_artifact_name="zubercal",
         input_file_list=files,
         ## NB - you need the parens here!
         file_reader=ZubercalParquetReader(),
@@ -84,7 +84,7 @@ Challenges with this data set
         catalog_type="source",
         ra_column="objra",
         dec_column="objdec",
-        id_column="objectid",
+        sort_columns="objectid",
         highest_healpix_order=10,
         pixel_threshold=20_000_000,
         output_path="/path/to/catalogs/",

--- a/docs/notebooks/unequal_schema.ipynb
+++ b/docs/notebooks/unequal_schema.ipynb
@@ -75,7 +75,7 @@
     "tmp_path = tempfile.TemporaryDirectory()\n",
     "\n",
     "args = ImportArguments(\n",
-    "    output_catalog_name=\"mixed_csv_bad\",\n",
+    "    output_artifact_name=\"mixed_csv_bad\",\n",
     "    input_path=mixed_schema_csv_dir,\n",
     "    input_format=\"csv\",\n",
     "    output_path=tmp_path.name,\n",
@@ -128,7 +128,7 @@
    "source": [
     "tmp_path = tempfile.TemporaryDirectory()\n",
     "args = ImportArguments(\n",
-    "    output_catalog_name=\"mixed_csv_good\",\n",
+    "    output_artifact_name=\"mixed_csv_good\",\n",
     "    input_path=mixed_schema_csv_dir,\n",
     "    input_format=\"csv\",\n",
     "    output_path=tmp_path.name,\n",

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -42,8 +42,10 @@ class ImportArguments(RuntimeArguments):
     """column for declination"""
     use_hipscat_index: bool = False
     """use an existing hipscat spatial index as the position, instead of ra/dec"""
-    id_column: str = "id"
-    """column for survey identifier, or other sortable column"""
+    sort_columns: str | None = None
+    """column for survey identifier, or other sortable column. if sorting by multiple columns,
+    they should be comma-separated. if `add_hipscat_index=True`, this sorting will be used to
+    resolve the counter within the same higher-order pixel space"""
     add_hipscat_index: bool = True
     """add the hipscat spatial index field alongside the data"""
     use_schema_file: str | None = None
@@ -115,7 +117,7 @@ class ImportArguments(RuntimeArguments):
     def to_catalog_info(self, total_rows) -> CatalogInfo:
         """Catalog-type-specific dataset info."""
         info = {
-            "catalog_name": self.output_catalog_name,
+            "catalog_name": self.output_artifact_name,
             "catalog_type": self.catalog_type,
             "total_rows": total_rows,
             "epoch": self.epoch,
@@ -126,7 +128,7 @@ class ImportArguments(RuntimeArguments):
 
     def additional_runtime_provenance_info(self) -> dict:
         return {
-            "catalog_name": self.output_catalog_name,
+            "catalog_name": self.output_artifact_name,
             "epoch": self.epoch,
             "catalog_type": self.catalog_type,
             "input_path": str(self.input_path),
@@ -136,7 +138,7 @@ class ImportArguments(RuntimeArguments):
             "ra_column": self.ra_column,
             "dec_column": self.dec_column,
             "use_hipscat_index": self.use_hipscat_index,
-            "id_column": self.id_column,
+            "sort_columns": self.sort_columns,
             "constant_healpix_order": self.constant_healpix_order,
             "highest_healpix_order": self.highest_healpix_order,
             "pixel_threshold": self.pixel_threshold,

--- a/src/hipscat_import/catalog/map_reduce.py
+++ b/src/hipscat_import/catalog/map_reduce.py
@@ -79,7 +79,7 @@ def _iterate_input_file(
                 )
             # Set up the pixel data
             mapped_pixels = hp.ang2pix(
-                2**highest_order,
+                2 ** highest_order,
                 data[ra_column].values,
                 data[dec_column].values,
                 lonlat=True,
@@ -194,7 +194,7 @@ def reduce_pixel_shards(
     output_path,
     ra_column,
     dec_column,
-    id_column,
+    sort_columns: str = "",
     use_hipscat_index=False,
     add_hipscat_index=True,
     delete_input_files=True,
@@ -230,7 +230,7 @@ def reduce_pixel_shards(
         destination_pixel_size (int): expected number of rows to write
             for the catalog's final pixel
         output_path (FilePointer): where to write the final catalog pixel data
-        id_column (str): column for survey identifier, or other sortable column
+        sort_columns (str): column for survey identifier, or other sortable column
         add_hipscat_index (bool): should we add a _hipscat_index column to
             the resulting parquet file?
         delete_input_files (bool): should we delete the intermediate files
@@ -273,8 +273,8 @@ def reduce_pixel_shards(
         )
 
     dataframe = merged_table.to_pandas()
-    if id_column:
-        dataframe = dataframe.sort_values(id_column)
+    if sort_columns:
+        dataframe = dataframe.sort_values(sort_columns.split(","))
     if add_hipscat_index and not use_hipscat_index:
         dataframe[HIPSCAT_ID_COLUMN] = pixel_math.compute_hipscat_id(
             dataframe[ra_column].values,

--- a/src/hipscat_import/catalog/run_import.py
+++ b/src/hipscat_import/catalog/run_import.py
@@ -95,7 +95,7 @@ def _reduce_pixels(args, destination_pixel_map, client):
                 output_path=args.catalog_path,
                 ra_column=args.ra_column,
                 dec_column=args.dec_column,
-                id_column=args.id_column,
+                sort_columns=args.sort_columns,
                 add_hipscat_index=args.add_hipscat_index,
                 use_schema_file=args.use_schema_file,
                 use_hipscat_index=args.use_hipscat_index,

--- a/src/hipscat_import/index/arguments.py
+++ b/src/hipscat_import/index/arguments.py
@@ -49,7 +49,7 @@ class IndexArguments(RuntimeArguments):
     def to_catalog_info(self, total_rows) -> IndexCatalogInfo:
         """Catalog-type-specific dataset info."""
         info = {
-            "catalog_name": self.output_catalog_name,
+            "catalog_name": self.output_artifact_name,
             "total_rows": total_rows,
             "catalog_type": "index",
             "primary_catalog": str(self.input_catalog_path),

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -64,7 +64,7 @@ class MarginCacheArguments(RuntimeArguments):
     def to_catalog_info(self, total_rows) -> MarginCacheCatalogInfo:
         """Catalog-type-specific dataset info."""
         info = {
-            "catalog_name": self.output_catalog_name,
+            "catalog_name": self.output_artifact_name,
             "total_rows": total_rows,
             "catalog_type": "margin",
             "primary_catalog": self.input_catalog_path,

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -19,7 +19,7 @@ def map_pixel_shards(
     data = file_io.load_parquet_to_pandas(partition_file)
 
     data["margin_pixel"] = hp.ang2pix(
-        2**margin_order,
+        2 ** margin_order,
         data[ra_column].values,
         data[dec_column].values,
         lonlat=True,

--- a/src/hipscat_import/pipeline.py
+++ b/src/hipscat_import/pipeline.py
@@ -68,7 +68,7 @@ def _send_failure_email(args: RuntimeArguments, exception: Exception):
     message["Subject"] = "hipscat-import failure."
     message["To"] = args.completion_email_address
     message.set_content(
-        f"output_catalog_name: {args.output_catalog_name}"
+        f"output_artifact_name: {args.output_artifact_name}"
         "\n\nSee logs for more details"
         f"\n\nFailed with message:\n\n{exception}"
     )
@@ -82,7 +82,7 @@ def _send_success_email(args):
     message = EmailMessage()
     message["Subject"] = "hipscat-import success."
     message["To"] = args.completion_email_address
-    message.set_content(f"output_catalog_name: {args.output_catalog_name}")
+    message.set_content(f"output_artifact_name: {args.output_artifact_name}")
 
     _send_email(message)
 

--- a/src/hipscat_import/runtime_arguments.py
+++ b/src/hipscat_import/runtime_arguments.py
@@ -18,7 +18,7 @@ class RuntimeArguments:
     ## Output
     output_path: str = ""
     """base path where new catalog should be output"""
-    output_catalog_name: str = ""
+    output_artifact_name: str = ""
     """short, convenient name for the catalog"""
 
     ## Execution
@@ -44,7 +44,7 @@ class RuntimeArguments:
 
     catalog_path: FilePointer | None = None
     """constructed output path for the catalog that will be something like
-    <output_path>/<output_catalog_name>"""
+    <output_path>/<output_artifact_name>"""
     tmp_path: FilePointer | None = None
     """constructed temp path - defaults to tmp_dir, then dask_tmp, but will create
     a new temp directory under catalog_path if no other options are provided"""
@@ -55,17 +55,17 @@ class RuntimeArguments:
     def _check_arguments(self):
         if not self.output_path:
             raise ValueError("output_path is required")
-        if not self.output_catalog_name:
-            raise ValueError("output_catalog_name is required")
-        if re.search(r"[^A-Za-z0-9_\-\\]", self.output_catalog_name):
-            raise ValueError("output_catalog_name contains invalid characters")
+        if not self.output_artifact_name:
+            raise ValueError("output_artifact_name is required")
+        if re.search(r"[^A-Za-z0-9_\-\\]", self.output_artifact_name):
+            raise ValueError("output_artifact_name contains invalid characters")
 
         if self.dask_n_workers <= 0:
             raise ValueError("dask_n_workers should be greather than 0")
         if self.dask_threads_per_worker <= 0:
             raise ValueError("dask_threads_per_worker should be greater than 0")
 
-        self.catalog_path = file_io.append_paths_to_pointer(self.output_path, self.output_catalog_name)
+        self.catalog_path = file_io.append_paths_to_pointer(self.output_path, self.output_artifact_name)
         if not self.overwrite:
             if file_io.directory_has_contents(self.catalog_path):
                 raise ValueError(
@@ -78,13 +78,13 @@ class RuntimeArguments:
             if not file_io.does_file_or_directory_exist(self.tmp_dir):
                 raise FileNotFoundError(f"tmp_dir ({self.tmp_dir}) not found on local storage")
             self.tmp_path = file_io.append_paths_to_pointer(
-                self.tmp_dir, self.output_catalog_name, "intermediate"
+                self.tmp_dir, self.output_artifact_name, "intermediate"
             )
         elif self.dask_tmp:
             if not file_io.does_file_or_directory_exist(self.dask_tmp):
                 raise FileNotFoundError(f"dask_tmp ({self.dask_tmp}) not found on local storage")
             self.tmp_path = file_io.append_paths_to_pointer(
-                self.dask_tmp, self.output_catalog_name, "intermediate"
+                self.dask_tmp, self.output_artifact_name, "intermediate"
             )
         else:
             self.tmp_path = file_io.append_paths_to_pointer(self.catalog_path, "intermediate")
@@ -97,9 +97,9 @@ class RuntimeArguments:
             dictionary with all argument_name -> argument_value as key -> value pairs.
         """
         runtime_args = {
-            "catalog_name": self.output_catalog_name,
+            "catalog_name": self.output_artifact_name,
             "output_path": str(self.output_path),
-            "output_catalog_name": self.output_catalog_name,
+            "output_artifact_name": self.output_artifact_name,
             "tmp_dir": str(self.tmp_dir),
             "overwrite": self.overwrite,
             "dask_tmp": str(self.dask_tmp),

--- a/src/hipscat_import/soap/arguments.py
+++ b/src/hipscat_import/soap/arguments.py
@@ -50,7 +50,7 @@ class SoapArguments(RuntimeArguments):
     def to_catalog_info(self, total_rows) -> AssociationCatalogInfo:
         """Catalog-type-specific dataset info."""
         info = {
-            "catalog_name": self.output_catalog_name,
+            "catalog_name": self.output_artifact_name,
             "catalog_type": CatalogType.ASSOCIATION,
             "total_rows": total_rows,
             "primary_column": self.object_id_column,

--- a/tests/hipscat_import/catalog/test_argument_validation.py
+++ b/tests/hipscat_import/catalog/test_argument_validation.py
@@ -19,7 +19,7 @@ def test_empty_required(small_sky_parts_dir, tmp_path):
     ## Input format is missing
     with pytest.raises(ValueError, match="input_format"):
         ImportArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             input_format=None,
             input_path=small_sky_parts_dir,
             output_path=tmp_path,
@@ -28,7 +28,7 @@ def test_empty_required(small_sky_parts_dir, tmp_path):
     ## Input path is missing
     with pytest.raises(ValueError, match="input_file"):
         ImportArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             input_path="",
             input_format="csv",
             output_path=tmp_path,
@@ -40,7 +40,7 @@ def test_invalid_paths(blank_data_dir, tmp_path):
     """Required arguments are provided, but paths aren't found."""
     ## Prove that it works with required args
     ImportArguments(
-        output_catalog_name="catalog",
+        output_artifact_name="catalog",
         input_path=blank_data_dir,
         output_path=tmp_path,
         input_format="csv",
@@ -49,7 +49,7 @@ def test_invalid_paths(blank_data_dir, tmp_path):
     ## Bad input path
     with pytest.raises(FileNotFoundError):
         ImportArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             input_path="path",
             output_path=tmp_path,
             overwrite=True,
@@ -59,7 +59,7 @@ def test_invalid_paths(blank_data_dir, tmp_path):
     ## Input path has no files
     with pytest.raises(FileNotFoundError):
         ImportArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             input_path=blank_data_dir,
             output_path=tmp_path,
             overwrite=True,
@@ -71,7 +71,7 @@ def test_good_paths(blank_data_dir, blank_data_file, tmp_path):
     """Required arguments are provided, and paths are found."""
     tmp_path_str = str(tmp_path)
     args = ImportArguments(
-        output_catalog_name="catalog",
+        output_artifact_name="catalog",
         input_path=blank_data_dir,
         input_format="csv",
         output_path=tmp_path_str,
@@ -85,7 +85,7 @@ def test_good_paths(blank_data_dir, blank_data_file, tmp_path):
 def test_multiple_files_in_path(small_sky_parts_dir, tmp_path):
     """Required arguments are provided, and paths are found."""
     args = ImportArguments(
-        output_catalog_name="catalog",
+        output_artifact_name="catalog",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -97,7 +97,7 @@ def test_multiple_files_in_path(small_sky_parts_dir, tmp_path):
 def test_single_debug_file(formats_headers_csv, tmp_path):
     """Required arguments are provided, and paths are found."""
     args = ImportArguments(
-        output_catalog_name="catalog",
+        output_artifact_name="catalog",
         input_file_list=[formats_headers_csv],
         input_format="csv",
         output_path=tmp_path,
@@ -110,7 +110,7 @@ def test_healpix_args(blank_data_dir, tmp_path):
     """Test errors for healpix partitioning arguments"""
     with pytest.raises(ValueError, match="highest_healpix_order"):
         ImportArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             input_path=blank_data_dir,
             input_format="csv",
             output_path=tmp_path,
@@ -119,7 +119,7 @@ def test_healpix_args(blank_data_dir, tmp_path):
         )
     with pytest.raises(ValueError, match="pixel_threshold"):
         ImportArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             input_path=blank_data_dir,
             input_format="csv",
             output_path=tmp_path,
@@ -128,7 +128,7 @@ def test_healpix_args(blank_data_dir, tmp_path):
         )
     with pytest.raises(ValueError, match="constant_healpix_order"):
         ImportArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             input_path=blank_data_dir,
             input_format="csv",
             output_path=tmp_path,
@@ -141,7 +141,7 @@ def test_catalog_type(blank_data_dir, tmp_path):
     """Test errors for catalog types."""
     with pytest.raises(ValueError, match="catalog_type"):
         ImportArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             catalog_type=None,
             input_path=blank_data_dir,
             input_format="csv",
@@ -150,7 +150,7 @@ def test_catalog_type(blank_data_dir, tmp_path):
 
     with pytest.raises(ValueError, match="catalog_type"):
         ImportArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             catalog_type="association",
             input_path=blank_data_dir,
             input_format="csv",
@@ -161,7 +161,7 @@ def test_catalog_type(blank_data_dir, tmp_path):
 def test_to_catalog_info(blank_data_dir, tmp_path):
     """Verify creation of catalog parameters for catalog to be created."""
     args = ImportArguments(
-        output_catalog_name="catalog",
+        output_artifact_name="catalog",
         input_path=blank_data_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -175,7 +175,7 @@ def test_to_catalog_info(blank_data_dir, tmp_path):
 def test_provenance_info(blank_data_dir, tmp_path):
     """Verify that provenance info includes catalog-specific fields."""
     args = ImportArguments(
-        output_catalog_name="catalog",
+        output_artifact_name="catalog",
         input_path=blank_data_dir,
         input_format="csv",
         output_path=tmp_path,

--- a/tests/hipscat_import/catalog/test_map_reduce.py
+++ b/tests/hipscat_import/catalog/test_map_reduce.py
@@ -286,7 +286,7 @@ def test_reduce_order0(parquet_shards_dir, assert_parquet_file_ids, tmp_path):
         add_hipscat_index=True,
         ra_column="ra",
         dec_column="dec",
-        id_column="id",
+        sort_columns="id",
         delete_input_files=False,
     )
 
@@ -309,7 +309,7 @@ def test_reduce_hipscat_index(parquet_shards_dir, assert_parquet_file_ids, tmp_p
         output_path=tmp_path,
         ra_column="ra",
         dec_column="dec",
-        id_column="id",
+        sort_columns="id",
         delete_input_files=False,
     )
 
@@ -335,7 +335,7 @@ def test_reduce_hipscat_index(parquet_shards_dir, assert_parquet_file_ids, tmp_p
         add_hipscat_index=False,  ## different from above
         ra_column="ra",
         dec_column="dec",
-        id_column="id",
+        sort_columns="id",
         delete_input_files=False,
     )
 
@@ -363,7 +363,7 @@ def test_reduce_bad_expectation(parquet_shards_dir, tmp_path):
             output_path=tmp_path,
             ra_column="ra",
             dec_column="dec",
-            id_column="id",
+            sort_columns="id",
             delete_input_files=False,
         )
 
@@ -425,7 +425,7 @@ def test_reduce_with_sorting_complex(assert_parquet_file_ids, tmp_path):
         output_path=tmp_path,
         ra_column="ra",
         dec_column="dec",
-        id_column="source_id",
+        sort_columns="source_id",
         delete_input_files=False,
     )
 
@@ -462,7 +462,7 @@ def test_reduce_with_sorting_complex(assert_parquet_file_ids, tmp_path):
         output_path=tmp_path,
         ra_column="ra",
         dec_column="dec",
-        id_column=["object_id", "time"],
+        sort_columns="object_id,time",
         delete_input_files=False,
     )
 
@@ -499,7 +499,7 @@ def test_reduce_with_sorting_complex(assert_parquet_file_ids, tmp_path):
         output_path=tmp_path,
         ra_column="ra",
         dec_column="dec",
-        id_column=["object_id", "time"],
+        sort_columns="object_id,time",
         add_hipscat_index=False,
         delete_input_files=False,
     )

--- a/tests/hipscat_import/catalog/test_run_import.py
+++ b/tests/hipscat_import/catalog/test_run_import.py
@@ -20,7 +20,7 @@ def test_empty_args():
 
 def test_bad_args():
     """Runner should fail with mis-typed arguments"""
-    args = {"output_catalog_name": "bad_arg_type"}
+    args = {"output_artifact_name": "bad_arg_type"}
     with pytest.raises(ValueError, match="ImportArguments"):
         runner.run(args, None)
 
@@ -61,7 +61,7 @@ def test_resume_dask_runner(
     )
 
     args = ImportArguments(
-        output_catalog_name="resume",
+        output_artifact_name="resume",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -102,7 +102,7 @@ def test_resume_dask_runner(
     plan.touch_stage_done_file(ResumePlan.REDUCING_STAGE)
 
     args = ImportArguments(
-        output_catalog_name="resume",
+        output_artifact_name="resume",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -135,7 +135,7 @@ def test_dask_runner(
 ):
     """Test basic execution."""
     args = ImportArguments(
-        output_catalog_name="small_sky_object_catalog",
+        output_artifact_name="small_sky_object_catalog",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -166,7 +166,7 @@ def test_dask_runner(
 def test_dask_runner_stats_only(dask_client, small_sky_parts_dir, tmp_path):
     """Test basic execution, without generating catalog parquet outputs."""
     args = ImportArguments(
-        output_catalog_name="small_sky",
+        output_artifact_name="small_sky",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,

--- a/tests/hipscat_import/catalog/test_run_round_trip.py
+++ b/tests/hipscat_import/catalog/test_run_round_trip.py
@@ -30,13 +30,13 @@ def test_import_source_table(
     - will have larger partition info than the corresponding object catalog
     """
     args = ImportArguments(
-        output_catalog_name="small_sky_source_catalog",
+        output_artifact_name="small_sky_source_catalog",
         input_path=small_sky_source_dir,
         input_format="csv",
         catalog_type="source",
         ra_column="source_ra",
         dec_column="source_dec",
-        id_column="source_id",
+        sort_columns="source_id",
         output_path=tmp_path,
         dask_tmp=tmp_path,
         highest_healpix_order=2,
@@ -70,7 +70,7 @@ def test_import_mixed_schema_csv(
         and can be combined into a single parquet file.
     """
     args = ImportArguments(
-        output_catalog_name="mixed_csv_bad",
+        output_artifact_name="mixed_csv_bad",
         input_path=mixed_schema_csv_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -85,7 +85,7 @@ def test_import_mixed_schema_csv(
 
     ## Try again, but with the schema specified.
     args.use_schema_file = mixed_schema_csv_parquet
-    args.output_catalog_name = "mixed_csv_good"
+    args.output_artifact_name = "mixed_csv_good"
     runner.run(args, dask_client)
 
     # Check that the catalog parquet file exists
@@ -129,10 +129,10 @@ def test_import_preserve_index(
 
     ## Don't generate a hipscat index. Verify that the original index remains.
     args = ImportArguments(
-        output_catalog_name="pandasindex",
+        output_artifact_name="pandasindex",
         input_file_list=[formats_pandasindex],
         input_format="parquet",
-        id_column="obs_id",
+        sort_columns="obs_id",
         add_hipscat_index=False,
         output_path=tmp_path,
         dask_tmp=tmp_path,
@@ -155,10 +155,10 @@ def test_import_preserve_index(
 
     ## DO generate a hipscat index. Verify that the original index is preserved in a column.
     args = ImportArguments(
-        output_catalog_name="pandasindex_preserve",
+        output_artifact_name="pandasindex_preserve",
         input_file_list=[formats_pandasindex],
         input_format="parquet",
-        id_column="obs_id",
+        sort_columns="obs_id",
         add_hipscat_index=True,
         output_path=tmp_path,
         dask_tmp=tmp_path,
@@ -220,10 +220,10 @@ def test_import_multiindex(
 
     ## Don't generate a hipscat index. Verify that the original index remains.
     args = ImportArguments(
-        output_catalog_name="multiindex",
+        output_artifact_name="multiindex",
         input_file_list=[formats_multiindex],
         input_format="parquet",
-        id_column=["obj_id", "band"],
+        sort_columns="obj_id,band",
         add_hipscat_index=False,
         output_path=tmp_path,
         dask_tmp=tmp_path,
@@ -246,10 +246,10 @@ def test_import_multiindex(
 
     ## DO generate a hipscat index. Verify that the original index is preserved in a column.
     args = ImportArguments(
-        output_catalog_name="multiindex_preserve",
+        output_artifact_name="multiindex_preserve",
         input_file_list=[formats_multiindex],
         input_format="parquet",
-        id_column=["obj_id", "band"],
+        sort_columns="obj_id,band",
         add_hipscat_index=True,
         output_path=tmp_path,
         dask_tmp=tmp_path,
@@ -282,7 +282,7 @@ def test_import_constant_healpix_order(
         and that we don't create tiles where there is no data.
     """
     args = ImportArguments(
-        output_catalog_name="small_sky_object_catalog",
+        output_artifact_name="small_sky_object_catalog",
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
@@ -331,7 +331,7 @@ def test_import_starr_file(
                 return super().read(file)
 
     args = ImportArguments(
-        output_catalog_name="starr",
+        output_artifact_name="starr",
         input_file_list=[formats_dir],
         input_format="starr",
         file_reader=StarrReader(),
@@ -379,7 +379,7 @@ def test_import_hipscat_index(
     npt.assert_array_equal(data_frame.columns, ["id"])
 
     args = ImportArguments(
-        output_catalog_name="using_hipscat_index",
+        output_artifact_name="using_hipscat_index",
         input_file_list=[input_file],
         input_format="parquet",
         output_path=tmp_path,
@@ -389,7 +389,7 @@ def test_import_hipscat_index(
         highest_healpix_order=2,
         pixel_threshold=3_000,
         progress_bar=False,
-        id_column="_hipscat_index",
+        sort_columns="_hipscat_index",
     )
 
     runner.run(args, dask_client)

--- a/tests/hipscat_import/cross_match/test_macauff_arguments.py
+++ b/tests/hipscat_import/cross_match/test_macauff_arguments.py
@@ -16,7 +16,7 @@ def test_macauff_arguments(
     """Test that we can create a MacauffArguments instance with two valid catalogs."""
     args = MacauffArguments(
         output_path=tmp_path,
-        output_catalog_name="object_to_source",
+        output_artifact_name="object_to_source",
         tmp_dir=tmp_path,
         left_catalog_dir=small_sky_object_catalog,
         left_ra_column="ra",
@@ -44,7 +44,7 @@ def test_empty_required(
     ##  - default value
     required_args = [
         ["output_path", tmp_path],
-        ["output_catalog_name", "object_to_source"],
+        ["output_artifact_name", "object_to_source"],
         ["left_catalog_dir", small_sky_object_catalog],
         ["left_ra_column", "ra"],
         ["left_dec_column", "dec"],
@@ -71,7 +71,7 @@ def test_empty_required(
         with pytest.raises(ValueError, match=args[0]):
             MacauffArguments(
                 output_path=test_args[0],
-                output_catalog_name=test_args[1],
+                output_artifact_name=test_args[1],
                 tmp_dir=tmp_path,
                 left_catalog_dir=test_args[2],
                 left_ra_column=test_args[3],
@@ -95,7 +95,7 @@ def test_macauff_arguments_file_list(
     files = [path.join(small_sky_dir, "catalog.csv")]
     args = MacauffArguments(
         output_path=tmp_path,
-        output_catalog_name="object_to_source",
+        output_artifact_name="object_to_source",
         tmp_dir=tmp_path,
         left_catalog_dir=small_sky_object_catalog,
         left_ra_column="ra",
@@ -117,7 +117,7 @@ def test_macauff_args_invalid_catalog(small_sky_source_catalog, small_sky_dir, f
     with pytest.raises(ValueError, match="left_catalog_dir"):
         MacauffArguments(
             output_path=tmp_path,
-            output_catalog_name="object_to_source",
+            output_artifact_name="object_to_source",
             tmp_dir=tmp_path,
             left_catalog_dir=small_sky_dir,  # valid path, but not a catalog
             left_ra_column="ra",
@@ -137,7 +137,7 @@ def test_macauff_args_right_invalid_catalog(small_sky_object_catalog, small_sky_
     with pytest.raises(ValueError, match="right_catalog_dir"):
         MacauffArguments(
             output_path=tmp_path,
-            output_catalog_name="object_to_source",
+            output_artifact_name="object_to_source",
             tmp_dir=tmp_path,
             left_catalog_dir=small_sky_object_catalog,
             left_ra_column="ra",
@@ -159,7 +159,7 @@ def test_macauff_args_invalid_metadata_file(
     with pytest.raises(ValueError, match="column metadata file must"):
         MacauffArguments(
             output_path=tmp_path,
-            output_catalog_name="object_to_source",
+            output_artifact_name="object_to_source",
             tmp_dir=tmp_path,
             left_catalog_dir=small_sky_object_catalog,
             left_ra_column="ra",
@@ -181,7 +181,7 @@ def test_macauff_args_invalid_input_directory(
     with pytest.raises(FileNotFoundError, match="input_path not found"):
         MacauffArguments(
             output_path=tmp_path,
-            output_catalog_name="object_to_source",
+            output_artifact_name="object_to_source",
             tmp_dir=tmp_path,
             left_catalog_dir=small_sky_object_catalog,
             left_ra_column="ra",
@@ -203,7 +203,7 @@ def test_macauff_args_no_files(
     with pytest.raises(FileNotFoundError, match="No input files found"):
         MacauffArguments(
             output_path=tmp_path,
-            output_catalog_name="object_to_source",
+            output_artifact_name="object_to_source",
             tmp_dir=tmp_path,
             left_catalog_dir=small_sky_object_catalog,
             left_ra_column="ra",

--- a/tests/hipscat_import/cross_match/test_macauff_runner.py
+++ b/tests/hipscat_import/cross_match/test_macauff_runner.py
@@ -13,7 +13,7 @@ def test_bad_args(dask_client):
     with pytest.raises(TypeError, match="MacauffArguments"):
         runner.run(None, dask_client)
 
-    args = {"output_catalog_name": "bad_arg_type"}
+    args = {"output_artifact_name": "bad_arg_type"}
     with pytest.raises(TypeError, match="MacauffArguments"):
         runner.run(args, dask_client)
 
@@ -30,7 +30,7 @@ def test_no_implementation(
     """Test that we can create a MacauffArguments instance with two valid catalogs."""
     args = MacauffArguments(
         output_path=tmp_path,
-        output_catalog_name="object_to_source",
+        output_artifact_name="object_to_source",
         tmp_dir=tmp_path,
         left_catalog_dir=small_sky_object_catalog,
         left_ra_column="ra",

--- a/tests/hipscat_import/data/small_sky_object_catalog/provenance_info.json
+++ b/tests/hipscat_import/data/small_sky_object_catalog/provenance_info.json
@@ -13,7 +13,7 @@
         "runtime_args": {
             "catalog_name": "small_sky_object_catalog",
             "output_path": "/home/data",
-            "output_catalog_name": "small_sky_object_catalog",
+            "output_artifact_name": "small_sky_object_catalog",
             "tmp_dir": "",
             "overwrite": true,
             "dask_tmp": "/tmp/pytest-of-delucchi/pytest-1261/test_dask_runner0",
@@ -35,7 +35,7 @@
             "input_file_list": [],
             "ra_column": "ra",
             "dec_column": "dec",
-            "id_column": "id",
+            "sort_columns": "id",
             "highest_healpix_order": 1,
             "pixel_threshold": 1000000,
             "debug_stats_only": false,

--- a/tests/hipscat_import/data/small_sky_source_catalog/provenance_info.json
+++ b/tests/hipscat_import/data/small_sky_source_catalog/provenance_info.json
@@ -13,7 +13,7 @@
         "runtime_args": {
             "catalog_name": "small_sky_source_catalog",
             "output_path": "/home/data",
-            "output_catalog_name": "small_sky_source_catalog",
+            "output_artifact_name": "small_sky_source_catalog",
             "tmp_dir": "",
             "overwrite": true,
             "dask_tmp": "/tmp/pytest-of-delucchi/pytest-1261/test_dask_runner_source_table0",
@@ -31,7 +31,7 @@
             "input_file_list": [],
             "ra_column": "source_ra",
             "dec_column": "source_dec",
-            "id_column": "source_id",
+            "sort_columns": "source_id",
             "highest_healpix_order": 2,
             "pixel_threshold": 3000,
             "debug_stats_only": false,

--- a/tests/hipscat_import/index/test_index_argument.py
+++ b/tests/hipscat_import/index/test_index_argument.py
@@ -19,7 +19,7 @@ def test_empty_required(tmp_path, small_sky_object_catalog):
         IndexArguments(
             indexing_column="id",
             output_path=tmp_path,
-            output_catalog_name="small_sky_object_index",
+            output_artifact_name="small_sky_object_index",
         )
 
     ## Input path is bad
@@ -28,7 +28,7 @@ def test_empty_required(tmp_path, small_sky_object_catalog):
             input_catalog_path="/foo",
             indexing_column="id",
             output_path=tmp_path,
-            output_catalog_name="small_sky_object_index",
+            output_artifact_name="small_sky_object_index",
             overwrite=True,
         )
 
@@ -38,7 +38,7 @@ def test_empty_required(tmp_path, small_sky_object_catalog):
             input_catalog_path=small_sky_object_catalog,
             indexing_column="",
             output_path=tmp_path,
-            output_catalog_name="small_sky_object_index",
+            output_artifact_name="small_sky_object_index",
             overwrite=True,
         )
 
@@ -50,7 +50,7 @@ def test_invalid_paths(tmp_path, small_sky_object_catalog):
         input_catalog_path=small_sky_object_catalog,
         indexing_column="id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
     )
     ## Input path is invalid catalog
     with pytest.raises(ValueError, match="input_catalog_path not a valid catalog"):
@@ -58,7 +58,7 @@ def test_invalid_paths(tmp_path, small_sky_object_catalog):
             input_catalog_path="path",
             indexing_column="id",
             output_path=f"{tmp_path}/path",
-            output_catalog_name="small_sky_object_index",
+            output_artifact_name="small_sky_object_index",
         )
 
 
@@ -69,7 +69,7 @@ def test_good_paths(tmp_path, small_sky_object_catalog):
         input_catalog_path=small_sky_object_catalog,
         indexing_column="id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
     )
     assert args.input_catalog_path == small_sky_object_catalog
     assert str(args.output_path) == tmp_path_str
@@ -83,7 +83,7 @@ def test_column_inclusion_args(tmp_path, small_sky_object_catalog):
             input_catalog_path=small_sky_object_catalog,
             indexing_column="id",
             output_path=tmp_path,
-            output_catalog_name="small_sky_object_index",
+            output_artifact_name="small_sky_object_index",
             include_hipscat_index=False,
             include_order_pixel=False,
         )
@@ -91,7 +91,7 @@ def test_column_inclusion_args(tmp_path, small_sky_object_catalog):
         input_catalog_path=small_sky_object_catalog,
         indexing_column="id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
         overwrite=True,
         include_hipscat_index=True,
         include_order_pixel=True,
@@ -101,7 +101,7 @@ def test_column_inclusion_args(tmp_path, small_sky_object_catalog):
         input_catalog_path=small_sky_object_catalog,
         indexing_column="id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
         overwrite=True,
         include_hipscat_index=True,
         include_order_pixel=False,
@@ -110,7 +110,7 @@ def test_column_inclusion_args(tmp_path, small_sky_object_catalog):
         input_catalog_path=small_sky_object_catalog,
         indexing_column="id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
         overwrite=True,
         include_hipscat_index=False,
         include_order_pixel=True,
@@ -124,7 +124,7 @@ def test_compute_partition_size(tmp_path, small_sky_object_catalog):
             input_catalog_path=small_sky_object_catalog,
             indexing_column="id",
             output_path=tmp_path,
-            output_catalog_name="small_sky_object_index",
+            output_artifact_name="small_sky_object_index",
             compute_partition_size=10,  ## not a valid join option
         )
 
@@ -135,12 +135,12 @@ def test_to_catalog_info(small_sky_object_catalog, tmp_path):
         input_catalog_path=small_sky_object_catalog,
         indexing_column="id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
         include_hipscat_index=True,
         include_order_pixel=True,
     )
     catalog_info = args.to_catalog_info(total_rows=10)
-    assert catalog_info.catalog_name == args.output_catalog_name
+    assert catalog_info.catalog_name == args.output_artifact_name
     assert catalog_info.total_rows == 10
 
 
@@ -150,7 +150,7 @@ def test_provenance_info(small_sky_object_catalog, tmp_path):
         input_catalog_path=small_sky_object_catalog,
         indexing_column="id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
         include_hipscat_index=True,
         include_order_pixel=True,
     )

--- a/tests/hipscat_import/index/test_index_map_reduce.py
+++ b/tests/hipscat_import/index/test_index_map_reduce.py
@@ -23,7 +23,7 @@ def test_create_index(
         input_catalog_path=small_sky_object_catalog,
         indexing_column="id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
         overwrite=True,
         progress_bar=False,
     )
@@ -51,7 +51,7 @@ def test_create_index_no_hipscat_index(small_sky_object_catalog, tmp_path):
         indexing_column="id",
         include_hipscat_index=False,
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
         overwrite=True,
         progress_bar=False,
     )
@@ -72,7 +72,7 @@ def test_create_index_no_order_pixel(small_sky_object_catalog, tmp_path):
         indexing_column="id",
         include_order_pixel=False,
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
         overwrite=True,
         progress_bar=False,
     )
@@ -96,7 +96,7 @@ def test_create_index_source(
         input_catalog_path=small_sky_source_catalog,
         indexing_column="source_id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_source_index",
+        output_artifact_name="small_sky_source_index",
         overwrite=True,
         progress_bar=False,
     )
@@ -128,7 +128,7 @@ def test_create_index_source_by_object(
         input_catalog_path=small_sky_source_catalog,
         indexing_column="object_id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_source_index",
+        output_artifact_name="small_sky_source_index",
         overwrite=True,
         progress_bar=False,
     )
@@ -160,7 +160,7 @@ def test_create_index_extra_columns(
         indexing_column="object_id",
         output_path=tmp_path,
         extra_columns=["source_ra"],
-        output_catalog_name="small_sky_source_index",
+        output_artifact_name="small_sky_source_index",
         overwrite=True,
         progress_bar=False,
     )

--- a/tests/hipscat_import/index/test_run_index.py
+++ b/tests/hipscat_import/index/test_run_index.py
@@ -19,7 +19,7 @@ def test_empty_args():
 
 def test_bad_args():
     """Runner should fail with mis-typed arguments"""
-    args = {"output_catalog_name": "bad_arg_type"}
+    args = {"output_artifact_name": "bad_arg_type"}
     with pytest.raises(TypeError, match="IndexArguments"):
         runner.run(args)
 
@@ -35,7 +35,7 @@ def test_run_index(
         input_catalog_path=small_sky_object_catalog,
         indexing_column="id",
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_index",
+        output_artifact_name="small_sky_object_index",
         overwrite=True,
         progress_bar=False,
     )

--- a/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
@@ -15,7 +15,7 @@ def test_empty_required(tmp_path):
         MarginCacheArguments(
             margin_threshold=5.0,
             output_path=tmp_path,
-            output_catalog_name="catalog_cache",
+            output_artifact_name="catalog_cache",
         )
 
     ## Input catalog path is bad
@@ -24,7 +24,7 @@ def test_empty_required(tmp_path):
             input_catalog_path="/foo",
             margin_threshold=5.0,
             output_path=tmp_path,
-            output_catalog_name="catalog_cache",
+            output_artifact_name="catalog_cache",
             overwrite=True,
         )
 
@@ -35,7 +35,7 @@ def test_margin_order_dynamic(small_sky_source_catalog, tmp_path):
         margin_threshold=5.0,
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
-        output_catalog_name="catalog_cache",
+        output_artifact_name="catalog_cache",
     )
 
     assert args.margin_order == 3
@@ -47,7 +47,7 @@ def test_margin_order_static(small_sky_source_catalog, tmp_path):
         margin_threshold=5.0,
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
-        output_catalog_name="catalog_cache",
+        output_artifact_name="catalog_cache",
         margin_order=4,
     )
 
@@ -61,7 +61,7 @@ def test_margin_order_invalid(small_sky_source_catalog, tmp_path):
             margin_threshold=5.0,
             input_catalog_path=small_sky_source_catalog,
             output_path=tmp_path,
-            output_catalog_name="catalog_cache",
+            output_artifact_name="catalog_cache",
             margin_order=2,
         )
 
@@ -74,7 +74,7 @@ def test_margin_threshold_warns(small_sky_source_catalog, tmp_path):
             margin_threshold=360.0,
             input_catalog_path=small_sky_source_catalog,
             output_path=tmp_path,
-            output_catalog_name="catalog_cache",
+            output_artifact_name="catalog_cache",
             margin_order=16,
         )
 
@@ -85,11 +85,11 @@ def test_to_catalog_info(small_sky_source_catalog, tmp_path):
         margin_threshold=5.0,
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
-        output_catalog_name="catalog_cache",
+        output_artifact_name="catalog_cache",
         margin_order=4,
     )
     catalog_info = args.to_catalog_info(total_rows=10)
-    assert catalog_info.catalog_name == args.output_catalog_name
+    assert catalog_info.catalog_name == args.output_artifact_name
     assert catalog_info.total_rows == 10
 
 
@@ -99,7 +99,7 @@ def test_provenance_info(small_sky_source_catalog, tmp_path):
         margin_threshold=5.0,
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
-        output_catalog_name="catalog_cache",
+        output_artifact_name="catalog_cache",
         margin_order=4,
     )
 

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -18,7 +18,7 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
         margin_threshold=180.0,
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
-        output_catalog_name="catalog_cache",
+        output_artifact_name="catalog_cache",
         margin_order=8,
     )
 
@@ -43,7 +43,7 @@ def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, da
         margin_threshold=36000.0,
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
-        output_catalog_name="catalog_cache",
+        output_artifact_name="catalog_cache",
         margin_order=4,
     )
 
@@ -67,7 +67,7 @@ def test_partition_margin_pixel_pairs(small_sky_source_catalog, tmp_path):
         margin_threshold=5.0,
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
-        output_catalog_name="catalog_cache",
+        output_artifact_name="catalog_cache",
     )
 
     margin_pairs = mc._find_partition_margin_pixel_pairs(
@@ -86,7 +86,7 @@ def test_partition_margin_pixel_pairs_negative(small_sky_source_catalog, tmp_pat
         margin_threshold=5.0,
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
-        output_catalog_name="catalog_cache",
+        output_artifact_name="catalog_cache",
     )
 
     partition_stats = args.catalog.partition_info.get_healpix_pixels()
@@ -111,7 +111,7 @@ def test_create_margin_directory(small_sky_source_catalog, tmp_path):
         margin_threshold=5.0,
         input_catalog_path=small_sky_source_catalog,
         output_path=tmp_path,
-        output_catalog_name="catalog_cache",
+        output_artifact_name="catalog_cache",
     )
 
     mc._create_margin_directory(

--- a/tests/hipscat_import/soap/conftest.py
+++ b/tests/hipscat_import/soap/conftest.py
@@ -35,7 +35,7 @@ def small_sky_soap_args(small_sky_object_catalog, small_sky_source_catalog, tmp_
         object_id_column="id",
         source_catalog_dir=small_sky_source_catalog,
         source_object_id_column="object_id",
-        output_catalog_name="small_sky_association",
+        output_artifact_name="small_sky_association",
         output_path=tmp_path,
         overwrite=True,
         progress_bar=False,

--- a/tests/hipscat_import/soap/test_run_soap.py
+++ b/tests/hipscat_import/soap/test_run_soap.py
@@ -13,7 +13,7 @@ def test_empty_args():
 
 def test_bad_args():
     """Runner should fail with mis-typed arguments"""
-    args = {"output_catalog_name": "bad_arg_type"}
+    args = {"output_artifact_name": "bad_arg_type"}
     with pytest.raises(TypeError):
         runner.run(args, None)
 

--- a/tests/hipscat_import/soap/test_soap_arguments.py
+++ b/tests/hipscat_import/soap/test_soap_arguments.py
@@ -20,7 +20,7 @@ def test_empty_required(tmp_path, small_sky_object_catalog, small_sky_source_cat
         ["object_id_column", "id"],
         ["source_catalog_dir", small_sky_source_catalog],
         ["source_object_id_column", "object_id"],
-        ["output_catalog_name", "small_sky_association"],
+        ["output_artifact_name", "small_sky_association"],
         ["output_path", tmp_path],
     ]
 
@@ -38,7 +38,7 @@ def test_empty_required(tmp_path, small_sky_object_catalog, small_sky_source_cat
                 object_id_column=test_args[1],
                 source_catalog_dir=test_args[2],
                 source_object_id_column=test_args[3],
-                output_catalog_name=test_args[4],
+                output_artifact_name=test_args[4],
                 output_path=test_args[5],
                 ## always set these False
                 progress_bar=False,
@@ -55,7 +55,7 @@ def test_catalog_paths(tmp_path, small_sky_object_catalog, small_sky_source_cata
             object_id_column="id",
             source_catalog_dir=small_sky_source_catalog,
             source_object_id_column="object_id",
-            output_catalog_name="small_sky_association",
+            output_artifact_name="small_sky_association",
             output_path=tmp_path,
             progress_bar=False,
             overwrite=True,
@@ -68,7 +68,7 @@ def test_catalog_paths(tmp_path, small_sky_object_catalog, small_sky_source_cata
             object_id_column="id",
             source_catalog_dir="/foo",
             source_object_id_column="object_id",
-            output_catalog_name="small_sky_association",
+            output_artifact_name="small_sky_association",
             output_path=tmp_path,
             progress_bar=False,
             overwrite=True,
@@ -83,7 +83,7 @@ def test_compute_partition_size(tmp_path, small_sky_object_catalog, small_sky_so
             object_id_column="id",
             source_catalog_dir=small_sky_source_catalog,
             source_object_id_column="object_id",
-            output_catalog_name="small_sky_association",
+            output_artifact_name="small_sky_association",
             output_path=tmp_path,
             progress_bar=False,
             compute_partition_size=10,  ## not a valid option

--- a/tests/hipscat_import/soap/test_soap_map_reduce.py
+++ b/tests/hipscat_import/soap/test_soap_map_reduce.py
@@ -30,7 +30,7 @@ def test_count_joins_missing(small_sky_source_catalog, tmp_path):
         object_id_column="source_id",
         source_catalog_dir=small_sky_source_catalog,
         source_object_id_column="source_id",
-        output_catalog_name="small_sky_association",
+        output_artifact_name="small_sky_association",
         output_path=tmp_path,
         progress_bar=False,
     )

--- a/tests/hipscat_import/test_runtime_arguments.py
+++ b/tests/hipscat_import/test_runtime_arguments.py
@@ -21,14 +21,14 @@ def test_empty_required(tmp_path):
     ## Output path is missing
     with pytest.raises(ValueError, match="output_path"):
         RuntimeArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             output_path="",
         )
 
     ## Output catalog name is missing
-    with pytest.raises(ValueError, match="output_catalog_name"):
+    with pytest.raises(ValueError, match="output_artifact_name"):
         RuntimeArguments(
-            output_catalog_name="",
+            output_artifact_name="",
             output_path=tmp_path,
         )
 
@@ -36,13 +36,13 @@ def test_empty_required(tmp_path):
 def test_catalog_name(tmp_path):
     """Check for safe catalog names."""
     RuntimeArguments(
-        output_catalog_name="good_name",
+        output_artifact_name="good_name",
         output_path=tmp_path,
     )
 
     with pytest.raises(ValueError, match="invalid character"):
         RuntimeArguments(
-            output_catalog_name="bad_a$$_name",
+            output_artifact_name="bad_a$$_name",
             output_path=tmp_path,
         )
 
@@ -51,30 +51,30 @@ def test_invalid_paths(tmp_path):
     """Required arguments are provided, but paths aren't found."""
     ## Bad temp path
     with pytest.raises(FileNotFoundError):
-        RuntimeArguments(output_catalog_name="catalog", output_path=tmp_path, tmp_dir="/foo/path")
+        RuntimeArguments(output_artifact_name="catalog", output_path=tmp_path, tmp_dir="/foo/path")
 
     ## Bad dask temp path
     with pytest.raises(FileNotFoundError):
-        RuntimeArguments(output_catalog_name="catalog", output_path=tmp_path, dask_tmp="/foo/path")
+        RuntimeArguments(output_artifact_name="catalog", output_path=tmp_path, dask_tmp="/foo/path")
 
 
 def test_output_overwrite(tmp_path):
     """Test that we can write to existing directory, but not one with contents"""
     ## Create the directory first
     RuntimeArguments(
-        output_catalog_name="blank",
+        output_artifact_name="blank",
         output_path=tmp_path,
     )
 
     with pytest.raises(ValueError, match="use --overwrite flag"):
         RuntimeArguments(
-            output_catalog_name="blank",
+            output_artifact_name="blank",
             output_path=tmp_path,
         )
 
     ## No error with overwrite flag
     RuntimeArguments(
-        output_catalog_name="blank",
+        output_artifact_name="blank",
         output_path=tmp_path,
         overwrite=True,
     )
@@ -83,7 +83,7 @@ def test_output_overwrite(tmp_path):
 def test_good_paths(tmp_path):
     """Required arguments are provided, and paths are found."""
     _ = RuntimeArguments(
-        output_catalog_name="catalog",
+        output_artifact_name="catalog",
         output_path=tmp_path,
         tmp_dir=tmp_path,
         dask_tmp=tmp_path,
@@ -101,7 +101,7 @@ def test_tmp_path_creation(tmp_path):
 
     ## If no tmp paths are given, use the output directory
     args = RuntimeArguments(
-        output_catalog_name="special_catalog",
+        output_artifact_name="special_catalog",
         output_path=output_path,
     )
     assert "special_catalog" in str(args.tmp_path)
@@ -109,7 +109,7 @@ def test_tmp_path_creation(tmp_path):
 
     ## Use the tmp path if provided
     args = RuntimeArguments(
-        output_catalog_name="special_catalog",
+        output_artifact_name="special_catalog",
         output_path=output_path,
         tmp_dir=temp_path,
         overwrite=True,
@@ -119,7 +119,7 @@ def test_tmp_path_creation(tmp_path):
 
     ## Use the dask tmp for temp, if all else fails
     args = RuntimeArguments(
-        output_catalog_name="special_catalog",
+        output_artifact_name="special_catalog",
         output_path=output_path,
         dask_tmp=dask_tmp_path,
         overwrite=True,
@@ -132,7 +132,7 @@ def test_dask_args(tmp_path):
     """Test errors for dask arguments"""
     with pytest.raises(ValueError, match="dask_n_workers"):
         RuntimeArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             output_path=tmp_path,
             dask_n_workers=-10,
             dask_threads_per_worker=1,
@@ -140,7 +140,7 @@ def test_dask_args(tmp_path):
 
     with pytest.raises(ValueError, match="dask_threads_per_worker"):
         RuntimeArguments(
-            output_catalog_name="catalog",
+            output_artifact_name="catalog",
             output_path=tmp_path,
             dask_n_workers=1,
             dask_threads_per_worker=-10,
@@ -150,7 +150,7 @@ def test_dask_args(tmp_path):
 def test_provenance_info(tmp_path):
     """Verify that provenance info ONLY includes general runtime fields."""
     args = RuntimeArguments(
-        output_catalog_name="catalog",
+        output_artifact_name="catalog",
         output_path=tmp_path,
         tmp_dir=tmp_path,
         dask_tmp=tmp_path,

--- a/tests/hipscat_import/verification/test_run_verification.py
+++ b/tests/hipscat_import/verification/test_run_verification.py
@@ -1,7 +1,7 @@
 import pytest
 
-from hipscat_import.verification.arguments import VerificationArguments
 import hipscat_import.verification.run_verification as runner
+from hipscat_import.verification.arguments import VerificationArguments
 
 
 def test_bad_args():
@@ -9,7 +9,7 @@ def test_bad_args():
     with pytest.raises(TypeError, match="VerificationArguments"):
         runner.run(None)
 
-    args = {"output_catalog_name": "bad_arg_type"}
+    args = {"output_artifact_name": "bad_arg_type"}
     with pytest.raises(TypeError, match="VerificationArguments"):
         runner.run(args)
 
@@ -19,7 +19,7 @@ def test_no_implementation(tmp_path, small_sky_object_catalog):
     args = VerificationArguments(
         input_catalog_path=small_sky_object_catalog,
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_verification_report",
+        output_artifact_name="small_sky_object_verification_report",
     )
     with pytest.raises(NotImplementedError, match="not yet implemented"):
         runner.run(args)

--- a/tests/hipscat_import/verification/test_verification_arguments.py
+++ b/tests/hipscat_import/verification/test_verification_arguments.py
@@ -18,7 +18,7 @@ def test_empty_required(tmp_path):
     with pytest.raises(ValueError, match="input_catalog_path"):
         VerificationArguments(
             output_path=tmp_path,
-            output_catalog_name="small_sky_object_verification_report",
+            output_artifact_name="small_sky_object_verification_report",
         )
 
 
@@ -28,7 +28,7 @@ def test_invalid_paths(tmp_path, small_sky_object_catalog):
     VerificationArguments(
         input_catalog_path=small_sky_object_catalog,
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_verification_report",
+        output_artifact_name="small_sky_object_verification_report",
     )
 
     ## Input path is invalid catalog
@@ -36,7 +36,7 @@ def test_invalid_paths(tmp_path, small_sky_object_catalog):
         VerificationArguments(
             input_catalog_path="path",
             output_path=f"{tmp_path}/path",
-            output_catalog_name="small_sky_object_verification_report",
+            output_artifact_name="small_sky_object_verification_report",
         )
 
 
@@ -46,7 +46,7 @@ def test_good_paths(tmp_path, small_sky_object_catalog):
     args = VerificationArguments(
         input_catalog_path=small_sky_object_catalog,
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_verification_report",
+        output_artifact_name="small_sky_object_verification_report",
     )
     assert args.input_catalog_path == small_sky_object_catalog
     assert str(args.output_path) == tmp_path_str
@@ -60,7 +60,7 @@ def test_catalog_object(tmp_path, small_sky_object_catalog):
     args = VerificationArguments(
         input_catalog=small_sky_catalog_object,
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_verification_report",
+        output_artifact_name="small_sky_object_verification_report",
     )
     assert args.input_catalog_path == small_sky_object_catalog
     assert str(args.output_path) == tmp_path_str
@@ -72,7 +72,7 @@ def test_provenance_info(small_sky_object_catalog, tmp_path):
     args = VerificationArguments(
         input_catalog_path=small_sky_object_catalog,
         output_path=tmp_path,
-        output_catalog_name="small_sky_object_verification_report",
+        output_artifact_name="small_sky_object_verification_report",
     )
 
     runtime_args = args.provenance_info()["runtime_args"]


### PR DESCRIPTION
## Change Description

Four refactors bundled up here:
- renames the argument `output_catalog_name` to `output_artifact_name` (see https://github.com/astronomy-commons/hipscat-import/pull/126)
- renames catalog import argument `id_column` to `sort_columns` (this field need not be an id (could be time), and can support more than one column)
- clarifies the type for `sort_columns` (was mixing `str` and `List[str]`)
- runs black and isort