### PR TITLE
Remove the explicit task key.

### DIFF
--- a/docs/notebooks/unequal_schema.ipynb
+++ b/docs/notebooks/unequal_schema.ipynb
@@ -82,12 +82,12 @@
     "    highest_healpix_order=1,\n",
     ")\n",
     "\n",
-    "client = Client(n_workers=1, threads_per_worker=1)\n",
-    "\n",
-    "try:\n",
-    "    pipeline_with_client(args, client)\n",
-    "except:\n",
-    "    pass  # we know it's going to fail!!"
+    "with Client(n_workers=1, threads_per_worker=1) as client:\n",
+    "    try:\n",
+    "        pipeline_with_client(args, client)\n",
+    "    except:\n",
+    "        pass  # we know it's going to fail!!\n",
+    "tmp_path.cleanup()"
    ]
   },
   {
@@ -137,7 +137,8 @@
     "    use_schema_file=mixed_schema_csv_parquet,\n",
     "    overwrite=True,\n",
     ")\n",
-    "pipeline_with_client(args, client)"
+    "with Client(n_workers=1, threads_per_worker=1) as client:\n",
+    "    pipeline_with_client(args, client)"
    ]
   },
   {
@@ -283,7 +284,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "client.shutdown()\n",
     "tmp_path.cleanup()"
    ]
   }
@@ -304,7 +304,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.4"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,

--- a/src/hipscat_import/catalog/run_import.py
+++ b/src/hipscat_import/catalog/run_import.py
@@ -27,7 +27,6 @@ def _map_pixels(args, client):
         futures.append(
             client.submit(
                 mr.map_to_pixels,
-                key=key,
                 input_file=file_path,
                 resume_path=args.resume_plan.tmp_path,
                 file_reader=reader_future,
@@ -53,7 +52,6 @@ def _split_pixels(args, alignment_future, client):
         futures.append(
             client.submit(
                 mr.split_pixels,
-                key=key,
                 input_file=file_path,
                 file_reader=reader_future,
                 highest_order=args.mapping_healpix_order,
@@ -85,7 +83,6 @@ def _reduce_pixels(args, destination_pixel_map, client):
         futures.append(
             client.submit(
                 mr.reduce_pixel_shards,
-                key=destination_pixel_key,
                 cache_shard_path=args.tmp_path,
                 resume_path=args.resume_plan.tmp_path,
                 reducing_key=destination_pixel_key,

--- a/src/hipscat_import/pipeline.py
+++ b/src/hipscat_import/pipeline.py
@@ -55,15 +55,15 @@ def pipeline_with_client(args: RuntimeArguments, client: Client):
             macauff_runner.run(args, client)
         else:
             raise ValueError("unknown args type")
-    except Exception as exception:  # pylint: disable=broad-exception-caught
-        _send_failure_email(args, exception)
-    else:
+
         _send_success_email(args)
+    except Exception as exception:  # pylint: disable=broad-exception-caught
+        if args.completion_email_address:
+            _send_failure_email(args, exception)
+        raise exception
 
 
 def _send_failure_email(args: RuntimeArguments, exception: Exception):
-    if not args.completion_email_address:
-        raise exception
     message = EmailMessage()
     message["Subject"] = "hipscat-import failure."
     message["To"] = args.completion_email_address

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -131,6 +131,8 @@ class PipelineResumePlan:
         ):
             if future.status == "error":
                 some_error = True
+                print(f"{stage_name} task {future.key} failed with message:")
+                print(future.exception())
         if some_error:
             raise RuntimeError(f"Some {stage_name} stages failed. See logs for details.")
 

--- a/src/hipscat_import/soap/run_soap.py
+++ b/src/hipscat_import/soap/run_soap.py
@@ -22,11 +22,10 @@ def run(args, client):
     resume_plan = SoapPlan(args)
     if not resume_plan.is_counting_done():
         futures = []
-        for source_pixel, object_pixels, source_key in resume_plan.count_keys:
+        for source_pixel, object_pixels, _source_key in resume_plan.count_keys:
             futures.append(
                 client.submit(
                     count_joins,
-                    key=source_key,
                     soap_args=args,
                     source_pixel=source_pixel,
                     object_pixels=object_pixels,


### PR DESCRIPTION
## Change Description

Fixes #172 .

## Solution Description

My theory on what's going on here is that dask sees that it already has some completed tasks with the name `split_<k>`, and so doesn't even try to run them when they're encountered in the second pipeline execution. PR #173 tried to work around this issue by re-initializing the client to clear out the tasks, but that doesn't feel good/sustainable.

We *were* using the future's key to log completed stages after task success, but PR #143 took that out, so we can just let dask assign its own task keys.