### PR TITLE
Add metadata files when creating datasets

### DIFF
--- a/src/hipscat_import/index/run_index.py
+++ b/src/hipscat_import/index/run_index.py
@@ -1,6 +1,6 @@
 """Create columnar index of hipscat table using dask for parallelization"""
 
-from hipscat.io import file_io, write_metadata
+from hipscat.io import file_io, parquet_metadata, write_metadata
 from tqdm import tqdm
 
 import hipscat_import.index.map_reduce as mr
@@ -32,5 +32,5 @@ def run(args):
         step_progress.update(1)
         file_io.remove_directory(args.tmp_path, ignore_errors=True)
         step_progress.update(1)
-        write_metadata.write_parquet_metadata(args.catalog_path)
+        parquet_metadata.write_parquet_metadata(args.catalog_path, order_by_healpix=False)
         step_progress.update(1)

--- a/tests/hipscat_import/catalog/test_argument_validation.py
+++ b/tests/hipscat_import/catalog/test_argument_validation.py
@@ -44,6 +44,7 @@ def test_invalid_paths(blank_data_dir, tmp_path):
         input_path=blank_data_dir,
         output_path=tmp_path,
         input_format="csv",
+        progress_bar=False,
     )
 
     ## Bad input path
@@ -76,6 +77,7 @@ def test_good_paths(blank_data_dir, blank_data_file, tmp_path):
         input_format="csv",
         output_path=tmp_path_str,
         tmp_dir=tmp_path_str,
+        progress_bar=False,
     )
     assert args.input_path == blank_data_dir
     assert len(args.input_paths) == 1
@@ -89,6 +91,7 @@ def test_multiple_files_in_path(small_sky_parts_dir, tmp_path):
         input_path=small_sky_parts_dir,
         input_format="csv",
         output_path=tmp_path,
+        progress_bar=False,
     )
     assert args.input_path == small_sky_parts_dir
     assert len(args.input_paths) == 5
@@ -101,6 +104,7 @@ def test_single_debug_file(formats_headers_csv, tmp_path):
         input_file_list=[formats_headers_csv],
         input_format="csv",
         output_path=tmp_path,
+        progress_bar=False,
     )
     assert len(args.input_paths) == 1
     assert args.input_paths[0] == formats_headers_csv
@@ -166,6 +170,7 @@ def test_to_catalog_info(blank_data_dir, tmp_path):
         input_format="csv",
         output_path=tmp_path,
         tmp_dir=tmp_path,
+        progress_bar=False,
     )
     catalog_info = args.to_catalog_info(total_rows=10)
     assert catalog_info.catalog_name == "catalog"
@@ -180,6 +185,7 @@ def test_provenance_info(blank_data_dir, tmp_path):
         input_format="csv",
         output_path=tmp_path,
         tmp_dir=tmp_path,
+        progress_bar=False,
     )
 
     runtime_args = args.provenance_info()["runtime_args"]

--- a/tests/hipscat_import/catalog/test_run_import.py
+++ b/tests/hipscat_import/catalog/test_run_import.py
@@ -237,3 +237,10 @@ def test_dask_runner_stats_only(dask_client, small_sky_parts_dir, tmp_path):
     output_file = os.path.join(args.catalog_path, "Norder=0", "Dir=0", "Npix=11.parquet")
 
     assert not os.path.exists(output_file)
+
+    catalog = Catalog.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
+    assert catalog.catalog_info.ra_column == "ra"
+    assert catalog.catalog_info.dec_column == "dec"
+    assert len(catalog.get_healpix_pixels()) == 1

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -3,6 +3,7 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
+from hipscat.catalog.dataset.dataset import Dataset
 from hipscat.io import file_io, paths
 
 import hipscat_import.margin_cache.margin_cache as mc
@@ -20,6 +21,7 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
         output_path=tmp_path,
         output_artifact_name="catalog_cache",
         margin_order=8,
+        progress_bar=False,
     )
 
     assert args.catalog.catalog_info.ra_column == "source_ra"
@@ -35,6 +37,10 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
 
     assert len(data) == 13
 
+    catalog = Dataset.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
+
 
 @pytest.mark.dask(timeout=150)
 def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, dask_client):
@@ -45,6 +51,7 @@ def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, da
         output_path=tmp_path,
         output_artifact_name="catalog_cache",
         margin_order=4,
+        progress_bar=False,
     )
 
     assert args.catalog.catalog_info.ra_column == "source_ra"

--- a/tests/hipscat_import/test_runtime_arguments.py
+++ b/tests/hipscat_import/test_runtime_arguments.py
@@ -87,6 +87,7 @@ def test_good_paths(tmp_path):
         output_path=tmp_path,
         tmp_dir=tmp_path,
         dask_tmp=tmp_path,
+        progress_bar=False,
     )
 
 
@@ -103,6 +104,7 @@ def test_tmp_path_creation(tmp_path):
     args = RuntimeArguments(
         output_artifact_name="special_catalog",
         output_path=output_path,
+        progress_bar=False,
     )
     assert "special_catalog" in str(args.tmp_path)
     assert "unique_output_directory" in str(args.tmp_path)
@@ -113,6 +115,7 @@ def test_tmp_path_creation(tmp_path):
         output_path=output_path,
         tmp_dir=temp_path,
         overwrite=True,
+        progress_bar=False,
     )
     assert "special_catalog" in str(args.tmp_path)
     assert "unique_tmp_directory" in str(args.tmp_path)
@@ -154,6 +157,7 @@ def test_provenance_info(tmp_path):
         output_path=tmp_path,
         tmp_dir=tmp_path,
         dask_tmp=tmp_path,
+        progress_bar=False,
     )
 
     runtime_args = args.provenance_info()["runtime_args"]


### PR DESCRIPTION
## Change Description

Related to https://github.com/astronomy-commons/hipscat/issues/147

- Removes the `partition_info.csv` writing from catalog creation
- Writes out `_metadata` files for all created datasets
- Expands some tests to try loading the dataset after creation through import
- Suppresses the progress bar output in more unit tests