### PR TITLE
Rename Margin Cache Hive Columns

### DIFF
--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -84,6 +84,12 @@ def _to_pixel_shard(data, margin_threshold, output_path, ra_column, dec_column):
 
         final_df[PartitionInfo.METADATA_DIR_COLUMN_NAME] = dir_column
 
+        final_df = final_df.astype({
+            PartitionInfo.METADATA_ORDER_COLUMN_NAME: np.uint8,
+            PartitionInfo.METADATA_DIR_COLUMN_NAME: np.uint64,
+            PartitionInfo.METADATA_PIXEL_COLUMN_NAME: np.uint64,
+        })
+
         final_df.to_parquet(shard_path)
 
         del data, margin_data, final_df

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -5,7 +5,6 @@ from hipscat import pixel_math
 from hipscat.catalog.partition_info import PartitionInfo
 from hipscat.io import file_io, paths
 
-
 # pylint: disable=too-many-locals,too-many-arguments
 
 

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -5,6 +5,7 @@ from hipscat import pixel_math
 from hipscat.catalog.partition_info import PartitionInfo
 from hipscat.io import file_io, paths
 
+
 # pylint: disable=too-many-locals,too-many-arguments
 
 
@@ -21,7 +22,7 @@ def map_pixel_shards(
     data = file_io.load_parquet_to_pandas(partition_file)
 
     data["margin_pixel"] = hp.ang2pix(
-        2 ** margin_order,
+        2**margin_order,
         data[ra_column].values,
         data[dec_column].values,
         lonlat=True,
@@ -68,15 +69,17 @@ def _to_pixel_shard(data, margin_threshold, output_path, ra_column, dec_column):
                 "margin_check",
                 "margin_pixel",
             ]
-        ).rename(
-            columns={
-                PartitionInfo.METADATA_ORDER_COLUMN_NAME: f"margin_{PartitionInfo.METADATA_ORDER_COLUMN_NAME}",
-                PartitionInfo.METADATA_DIR_COLUMN_NAME: f"margin_{PartitionInfo.METADATA_DIR_COLUMN_NAME}",
-                PartitionInfo.METADATA_PIXEL_COLUMN_NAME: f"margin_{PartitionInfo.METADATA_PIXEL_COLUMN_NAME}",
-                "partition_order": PartitionInfo.METADATA_ORDER_COLUMN_NAME,
-                "partition_pixel": PartitionInfo.METADATA_PIXEL_COLUMN_NAME
-            }
         )
+
+        rename_columns = {
+            PartitionInfo.METADATA_ORDER_COLUMN_NAME: f"margin_{PartitionInfo.METADATA_ORDER_COLUMN_NAME}",
+            PartitionInfo.METADATA_DIR_COLUMN_NAME: f"margin_{PartitionInfo.METADATA_DIR_COLUMN_NAME}",
+            PartitionInfo.METADATA_PIXEL_COLUMN_NAME: f"margin_{PartitionInfo.METADATA_PIXEL_COLUMN_NAME}",
+            "partition_order": PartitionInfo.METADATA_ORDER_COLUMN_NAME,
+            "partition_pixel": PartitionInfo.METADATA_PIXEL_COLUMN_NAME,
+        }
+
+        final_df.rename(columns=rename_columns, inplace=True)
 
         dir_column = np.floor_divide(final_df[PartitionInfo.METADATA_PIXEL_COLUMN_NAME].values, 10000) * 10000
 

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -3,6 +3,7 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
+from hipscat.catalog import PartitionInfo
 from hipscat.catalog.dataset.dataset import Dataset
 from hipscat.io import file_io, paths
 
@@ -36,6 +37,10 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
     data = pd.read_parquet(test_file)
 
     assert len(data) == 13
+
+    assert all(data[PartitionInfo.METADATA_ORDER_COLUMN_NAME] == norder)
+    assert all(data[PartitionInfo.METADATA_PIXEL_COLUMN_NAME] == npix)
+    assert all(data[PartitionInfo.METADATA_DIR_COLUMN_NAME] == int(npix / 10000) * 10000)
 
     catalog = Dataset.read_from_hipscat(args.catalog_path)
     assert catalog.on_disk

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -4,7 +4,7 @@ import numpy.testing as npt
 import pandas as pd
 import pytest
 from hipscat.catalog import PartitionInfo
-from hipscat.catalog.dataset.dataset import Dataset
+from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset
 from hipscat.io import file_io, paths
 
 import hipscat_import.margin_cache.margin_cache as mc
@@ -42,7 +42,11 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
     assert all(data[PartitionInfo.METADATA_PIXEL_COLUMN_NAME] == npix)
     assert all(data[PartitionInfo.METADATA_DIR_COLUMN_NAME] == int(npix / 10000) * 10000)
 
-    catalog = Dataset.read_from_hipscat(args.catalog_path)
+    assert data.dtypes[PartitionInfo.METADATA_ORDER_COLUMN_NAME] == np.uint8
+    assert data.dtypes[PartitionInfo.METADATA_DIR_COLUMN_NAME] == np.uint64
+    assert data.dtypes[PartitionInfo.METADATA_PIXEL_COLUMN_NAME] == np.uint64
+
+    catalog = HealpixDataset.read_from_hipscat(args.catalog_path)
     assert catalog.on_disk
     assert catalog.catalog_path == args.catalog_path
 


### PR DESCRIPTION
## Change Description

In the current margin cache generation, the values of the hive columns `NOrder`, `NPix`, and `Dir` are those from the margin's original pixel, and so do not match the hive values in the hipscat directory structure. This renames them to add the prefix `margin_`, ...,  and adds the hive columns that match the path to their pixel in the hipscat structure.
closes #188

- [x] My PR includes a link to the issue that I am addressing


## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [x] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)
