### PR TITLE
Fix margin cache generation leaving empty shard dirs

### DIFF
--- a/src/hipscat_import/margin_cache/margin_cache.py
+++ b/src/hipscat_import/margin_cache/margin_cache.py
@@ -145,5 +145,7 @@ def generate_margin_cache(args, client):
             catalog_base_dir=args.catalog_path, dataset_info=margin_catalog_info
         )
         step_progress.update(1)
+        cache_path = mcmr.get_cache_directory(args.catalog_path)
         file_io.remove_directory(args.tmp_path, ignore_errors=True)
+        file_io.remove_directory(cache_path, ignore_errors=True)
         step_progress.update(1)

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -55,7 +55,8 @@ def _to_pixel_shard(data, margin_threshold, output_path, ra_column, dec_column):
 
     if len(margin_data):
         # generate a file name for our margin shard, that uses both sets of Norder/Npix
-        partition_dir = get_pixel_cache_directory(output_path, HealpixPixel(order, pix))
+        cache_path = get_cache_directory(output_path)
+        partition_dir = get_pixel_cache_directory(cache_path, HealpixPixel(order, pix))
         shard_dir = paths.pixel_directory(partition_dir, source_order, source_pix)
 
         file_io.make_directory(shard_dir, exist_ok=True)
@@ -96,9 +97,14 @@ def _to_pixel_shard(data, margin_threshold, output_path, ra_column, dec_column):
         del data, margin_data, final_df
 
 
+def get_cache_directory(output_path):
+    return file_io.append_paths_to_pointer(output_path, "cache")
+
+
 def reduce_margin_shards(output_path, partition_order, partition_pixel):
     """Reduce all partition pixel directories into a single file"""
-    shard_dir = get_pixel_cache_directory(output_path, HealpixPixel(partition_order, partition_pixel))
+    cache_path = get_cache_directory(output_path)
+    shard_dir = get_pixel_cache_directory(cache_path, HealpixPixel(partition_order, partition_pixel))
 
     if file_io.does_file_or_directory_exist(shard_dir):
         data = ds.dataset(shard_dir, format="parquet")

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -98,6 +98,7 @@ def _to_pixel_shard(data, margin_threshold, output_path, ra_column, dec_column):
 
 
 def get_cache_directory(output_path):
+    """Generate the base path to store the pixel shards under"""
     return file_io.append_paths_to_pointer(output_path, "cache")
 
 

--- a/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
@@ -6,6 +6,7 @@ from hipscat.io import paths
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 from hipscat_import.margin_cache import margin_cache_map_reduce
+from hipscat_import.margin_cache.margin_cache_map_reduce import get_cache_directory
 from hipscat_import.pipeline_resume_plan import get_pixel_cache_directory
 
 keep_cols = ["weird_ra", "weird_dec"]
@@ -43,7 +44,9 @@ def test_to_pixel_shard_equator(tmp_path, basic_data_shard_df):
         dec_column="weird_dec",
     )
 
-    path = os.path.join(tmp_path, "order_1", "dir_0", "pixel_21", "Norder=1", "Dir=0", "Npix=0.parquet")
+    cache_path = get_cache_directory(tmp_path)
+
+    path = os.path.join(cache_path, "order_1", "dir_0", "pixel_21", "Norder=1", "Dir=0", "Npix=0.parquet")
 
     assert os.path.exists(path)
 
@@ -60,7 +63,9 @@ def test_to_pixel_shard_polar(tmp_path, polar_data_shard_df):
         dec_column="weird_dec",
     )
 
-    path = os.path.join(tmp_path, "order_2", "dir_0", "pixel_15", "Norder=2", "Dir=0", "Npix=0.parquet")
+    cache_path = get_cache_directory(tmp_path)
+
+    path = os.path.join(cache_path, "order_2", "dir_0", "pixel_15", "Norder=2", "Dir=0", "Npix=0.parquet")
 
     assert os.path.exists(path)
 
@@ -69,7 +74,8 @@ def test_to_pixel_shard_polar(tmp_path, polar_data_shard_df):
 
 @pytest.mark.dask
 def test_reduce_margin_shards(tmp_path, basic_data_shard_df):
-    partition_dir = get_pixel_cache_directory(tmp_path, HealpixPixel(1, 21))
+    cache_path = get_cache_directory(tmp_path)
+    partition_dir = get_pixel_cache_directory(cache_path, HealpixPixel(1, 21))
     shard_dir = paths.pixel_directory(partition_dir, 1, 21)
 
     os.makedirs(shard_dir)


### PR DESCRIPTION
## Change Description
Fixes a bug where generating a margin cache left the empty top level shard directories.


## Solution Description
In a previous PR, the margin cache shards were changed to be generated from the final pixel destination `Norder=x/Dir=y/Npix=z/...` to the same shard directories as other pipelines `order_x/dir_y/pix_z/...`. Before, these directories did not need to be deleted since they were used as the final structure, but now the new shard directory structures do need to be deleted.

To solve this, the shard files are now stored under a subdirectory `cache/order_x/...` which is deleted at the end of the pipeline.



## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

