### PR TITLE
Create partition info csvs on catalog creation.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "dask[distributed]",
     "deprecated",
     "healpy",
-    "hipscat >= 0.2.0",
+    "hipscat >= 0.2.4",
     "ipykernel", # Support for Jupyter notebooks
     "pandas < 2.1.0",
     "pyarrow",

--- a/src/hipscat_import/catalog/run_import.py
+++ b/src/hipscat_import/catalog/run_import.py
@@ -9,6 +9,7 @@ import hipscat.io.write_metadata as io
 import numpy as np
 from hipscat import pixel_math
 from hipscat.catalog import PartitionInfo
+from hipscat.io import paths
 from hipscat.io.parquet_metadata import write_parquet_metadata
 from tqdm import tqdm
 
@@ -168,10 +169,12 @@ def run(args, client):
             storage_options=args.output_storage_options,
         )
         step_progress.update(1)
+        partition_info = PartitionInfo.from_healpix(destination_pixel_map.keys())
+        partition_info_file = paths.get_partition_info_pointer(args.catalog_path)
+        partition_info.write_to_file(partition_info_file, storage_options=args.output_storage_options)
         if not args.debug_stats_only:
             write_parquet_metadata(args.catalog_path, storage_options=args.output_storage_options)
         else:
-            partition_info = PartitionInfo.from_healpix(destination_pixel_map.keys())
             partition_info.write_to_metadata_files(
                 args.catalog_path, storage_options=args.output_storage_options
             )

--- a/src/hipscat_import/soap/run_soap.py
+++ b/src/hipscat_import/soap/run_soap.py
@@ -3,6 +3,7 @@ Methods in this file set up a dask pipeline using futures.
 The actual logic of the map reduce is in the `map_reduce.py` file.
 """
 
+from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
 from hipscat.io import parquet_metadata, paths, write_metadata
 from tqdm import tqdm
 
@@ -57,6 +58,12 @@ def run(args, client):
             metadata_path = paths.get_parquet_metadata_pointer(args.catalog_path)
             for row_group in parquet_metadata.read_row_group_fragments(metadata_path):
                 total_rows += row_group.num_rows
+            partition_join_info = PartitionJoinInfo.read_from_file(
+                metadata_path, storage_options=args.output_storage_options
+            )
+            partition_join_info.write_to_csv(
+                catalog_path=args.catalog_path, storage_options=args.output_storage_options
+            )
         else:
             total_rows = combine_partial_results(args.tmp_path, args.catalog_path)
         step_progress.update(1)


### PR DESCRIPTION
## Change Description

We've determined that loading from partition_info / partition_join_info CSVs is significantly faster than loading from _metadata, and this re-adds the generation of these files during catalog creation.