### PR TITLE
Add copy button to readthedocs

### DIFF
--- a/docs/catalogs/arguments.rst
+++ b/docs/catalogs/arguments.rst
@@ -220,6 +220,7 @@ There are several stages to the pipeline execution, and you can expect progress
 reporting to look like the following:
 
 .. code-block::
+    :class: no-copybutton
 
     Mapping  : 100%|██████████| 72/72 [58:55:18<00:00, 2946.09s/it]
     Binning  : 100%|██████████| 1/1 [01:15<00:00, 75.16s/it]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,16 +24,23 @@ version = ".".join(release.split(".")[:2])
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.mathjax", "sphinx.ext.napoleon", "sphinx.ext.viewcode"]
-
-extensions.append("autoapi.extension")
-extensions.append("nbsphinx")
-
 templates_path = []
 exclude_patterns = ["_build", "**.ipynb_checkpoints"]
 
 # This assumes that sphinx-build is called from the root directory
 master_doc = "index"
+html_theme = "sphinx_rtd_theme"
+
+extensions = [
+    "sphinx.ext.mathjax",
+    "sphinx.ext.napoleon",
+    "sphinx.ext.viewcode",
+    "sphinx_copybutton",
+    "autoapi.extension",
+    "nbsphinx",
+]
+
+# -- autoapi configuration ----------------------------------------
 # Remove 'view source code' from top of page (for html, not python)
 html_show_sourcelink = False
 # Remove namespaces from class/method signatures
@@ -46,4 +53,12 @@ autoapi_add_toc_tree_entry = False
 autoapi_member_order = "bysource"
 
 napoleon_google_docstring = True
-html_theme = "sphinx_rtd_theme"
+
+# -- sphinx-copybutton configuration ----------------------------------------
+## sets up the expected prompt text from console blocks, and excludes it from
+## the text that goes into the clipboard.
+copybutton_exclude = ".linenos, .gp"
+copybutton_prompt_text = ">> "
+
+## lets us suppress the copy button on select code blocks.
+copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"

--- a/docs/guide/contributing.rst
+++ b/docs/guide/contributing.rst
@@ -33,7 +33,7 @@ virtual environment. LINCC-Frameworks engineers primarily use `conda` to manage 
 environments. If you have conda installed locally, you can run the following to
 create and activate a new environment.
 
-.. code-block:: bash
+.. code-block:: console
 
    >> conda create env -n <env_name> python=3.10
    >> conda activate <env_name>
@@ -42,7 +42,7 @@ create and activate a new environment.
 Once you have created a new environment, you can install this project for local
 development using the following commands:
 
-.. code-block:: bash
+.. code-block:: console
 
    >> pip install -e .'[dev]'
    >> pre-commit install
@@ -70,19 +70,19 @@ Notes:
     `do not yet exist <https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users>`_, 
     so it's recommended to install via conda before proceeding to hipscat-import.
 
-    .. code-block:: bash
+    .. code-block:: console
 
-        $ conda config --add channels conda-forge
-        $ conda install healpy
-        $ git clone https://github.com/astronomy-commons/hipscat-import
-        $ cd hipscat-import
-        $ pip install -e .
+        >> conda config --add channels conda-forge
+        >> conda install healpy
+        >> git clone https://github.com/astronomy-commons/hipscat-import
+        >> cd hipscat-import
+        >> pip install -e .
         
     When installing dev dependencies, make sure to include the single quotes.
 
-    .. code-block:: bash
+    .. code-block:: console
         
-        $ pip install -e '.[dev]'
+        >> pip install -e '.[dev]'
 
 Testing
 -------------------------------------------------------------------------------
@@ -97,17 +97,17 @@ paths. These are defined in ``conftest.py`` files. They're powerful and flexible
 Please add or update unit tests for all changes made to the codebase. You can run
 unit tests locally simply with:
 
-.. code-block:: bash
+.. code-block:: console
 
-    pytest
+    >> pytest
 
 If you're making changes to the sphinx documentation (anything under ``docs``),
 you can build the documentation locally with a command like:
 
-.. code-block:: bash
+.. code-block:: console
 
-    cd docs
-    make html
+    >> cd docs
+    >> make html
 
 Create your PR
 -------------------------------------------------------------------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,7 +9,7 @@ Installation
 We recommend installing in a virtual environment, like venv or conda. You may
 need to install or upgrade versions of dependencies to work with hipscat-import.
 
-.. code-block:: bash
+.. code-block:: console
 
     pip install hipscat-import
 
@@ -21,10 +21,10 @@ need to install or upgrade versions of dependencies to work with hipscat-import.
     `do not yet exist <https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users>`_, 
     so it's recommended to install via conda before proceeding to hipscat-import.
 
-    .. code-block:: bash
+    .. code-block:: console
 
-        $ conda config --append channels conda-forge
-        $ conda install healpy
+        >> conda config --append channels conda-forge
+        >> conda install healpy
 
 Setting up a pipeline
 -------------------------------------------------------------------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,3 +5,4 @@ nbsphinx
 ipython
 jupytext
 jupyter
+sphinx-copybutton


### PR DESCRIPTION
## Change Description

Adds a copy button to all code blocks in our readthedocs. 

:exploding_head: this also adds the copy button to all of the code blocks inside rendered notebooks. It's kind of wild.

see also: https://github.com/lincc-frameworks/python-project-template/pull/408