### PR TITLE
Fix soap arguments to catalog info not including all parameters

### DIFF
--- a/src/hipscat_import/soap/arguments.py
+++ b/src/hipscat_import/soap/arguments.py
@@ -61,6 +61,7 @@ class SoapArguments(RuntimeArguments):
             "primary_catalog": str(self.object_catalog_dir),
             "join_column": self.source_object_id_column,
             "join_catalog": str(self.source_catalog_dir),
+            "contains_leaf_files": self.write_leaf_files,
         }
         return AssociationCatalogInfo(**info)
 

--- a/tests/hipscat_import/soap/test_run_soap.py
+++ b/tests/hipscat_import/soap/test_run_soap.py
@@ -30,6 +30,7 @@ def test_object_to_source(dask_client, small_sky_soap_args):
     assert catalog.catalog_path == small_sky_soap_args.catalog_path
     assert len(catalog.get_join_pixels()) == 14
     assert catalog.catalog_info.total_rows == 17161
+    assert not catalog.catalog_info.contains_leaf_files
 
 
 @pytest.mark.dask
@@ -57,3 +58,4 @@ def test_object_to_source_with_leaves(
     assert catalog.catalog_path == small_sky_soap_args.catalog_path
     assert len(catalog.get_join_pixels()) == 14
     assert catalog.catalog_info.total_rows == 17161
+    assert catalog.catalog_info.contains_leaf_files


### PR DESCRIPTION

## Change Description
When running SOAP, the `write_leaf_files` argument did not correctly write the catalog_info parameter `contains_leaf_files`. This updates the soap arguments `to_catalog_info` method to include this.


## Code Quality
- [x] I have read the Contribution Guide
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [x] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)

