### PR TITLE
Use auto mode for tqdm for nicer notebook render

### DIFF
--- a/docs/catalogs/public/sdss.rst
+++ b/docs/catalogs/public/sdss.rst
@@ -29,7 +29,7 @@ Example conversion
     import glob
     import re
     import pandas as pd
-    from tqdm import tqdm
+    from tqdm.auto import tqdm
     from astropy.table import Table
     from astropy.table.table import descr
 

--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -10,7 +10,7 @@ from hipscat import pixel_math
 from hipscat.io import FilePointer, file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from numpy import frombuffer
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from hipscat_import.pipeline_resume_plan import PipelineResumePlan
 

--- a/src/hipscat_import/catalog/run_import.py
+++ b/src/hipscat_import/catalog/run_import.py
@@ -10,7 +10,7 @@ from hipscat import pixel_math
 from hipscat.catalog import PartitionInfo
 from hipscat.io import paths
 from hipscat.io.parquet_metadata import write_parquet_metadata
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 import hipscat_import.catalog.map_reduce as mr
 from hipscat_import.catalog.arguments import ImportArguments

--- a/src/hipscat_import/index/run_index.py
+++ b/src/hipscat_import/index/run_index.py
@@ -1,7 +1,7 @@
 """Create columnar index of hipscat table using dask for parallelization"""
 
 from hipscat.io import file_io, parquet_metadata, write_metadata
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 import hipscat_import.index.map_reduce as mr
 from hipscat_import.index.arguments import IndexArguments

--- a/src/hipscat_import/margin_cache/margin_cache.py
+++ b/src/hipscat_import/margin_cache/margin_cache.py
@@ -3,7 +3,7 @@ from dask.distributed import as_completed
 from hipscat import pixel_math
 from hipscat.catalog import PartitionInfo
 from hipscat.io import file_io, parquet_metadata, paths, write_metadata
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 import hipscat_import.margin_cache.margin_cache_map_reduce as mcmr
 

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from dask.distributed import as_completed
 from hipscat.io import FilePointer, file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 
 @dataclass

--- a/src/hipscat_import/soap/resume_plan.py
+++ b/src/hipscat_import/soap/resume_plan.py
@@ -11,7 +11,7 @@ from hipscat.catalog import Catalog
 from hipscat.io import file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from hipscat.pixel_tree import PixelAlignment, align_trees
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from hipscat_import.pipeline_resume_plan import PipelineResumePlan
 from hipscat_import.soap.arguments import SoapArguments

--- a/src/hipscat_import/soap/run_soap.py
+++ b/src/hipscat_import/soap/run_soap.py
@@ -5,7 +5,7 @@ The actual logic of the map reduce is in the `map_reduce.py` file.
 
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
 from hipscat.io import parquet_metadata, paths, write_metadata
-from tqdm import tqdm
+from tqdm.auto import tqdm
 
 from hipscat_import.pipeline_resume_plan import PipelineResumePlan
 from hipscat_import.soap.arguments import SoapArguments


### PR DESCRIPTION
## Change Description

Related to https://github.com/astronomy-commons/lsdb/issues/167

Uses `tqdm.auto` to allow tqdm to pick between standard err output, and the prettier notebook output. This would just be a nice thing for users, if they're working inside a notebook, to have the prettier progress bars.