### PR TITLE
Address smoke test failure

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -46,7 +46,7 @@ jobs:
       uses: slackapi/slack-github-action@v1
       with:
         # For posting a rich message using Block Kit
-        payload: | # The payload defined here can be customized to you liking https://api.slack.com/reference/block-kit/blocks 
+        payload: |
           {
             "blocks": [
               {
@@ -60,7 +60,7 @@ jobs:
                 "type": "section",
                 "text": {
                   "type": "mrkdwn",
-                  "text": "GitHub Action build result: *${{ job.status }}* :${{ job.status }}:" # Note that we expect the slack workspace to have an emoji called “failed” in this case.
+                  "text": "GitHub Action build result: *${{ job.status }}* :${{ job.status }}:"
                 }
               },
               {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "dask",
+    "dask<=2024.2.0",
     "dask[distributed]",
     "deprecated",
     "healpy",


### PR DESCRIPTION
## Change Description

Dask has introduced some flakiness in our tests in version 2024.2.1, so I'm pinning to 2024.2.0.

Additionally, we should have received alerts via the slackbot, but I believe the comments in the `payload` are creating invalid JSON.

https://github.com/astronomy-commons/hipscat-import/actions/runs/8044798259/job/21968976273