### PR TITLE
Force object and source ID in soap output.

### DIFF
--- a/src/hipscat_import/soap/arguments.py
+++ b/src/hipscat_import/soap/arguments.py
@@ -58,8 +58,10 @@ class SoapArguments(RuntimeArguments):
             "catalog_type": CatalogType.ASSOCIATION,
             "total_rows": total_rows,
             "primary_column": self.object_id_column,
+            "primary_column_association": "object_id",
             "primary_catalog": self.object_catalog_dir,
             "join_column": self.source_object_id_column,
+            "join_column_association": "source_id",
             "join_catalog": self.source_catalog_dir,
             "contains_leaf_files": self.write_leaf_files,
         }


### PR DESCRIPTION
## Change Description

Closes #214. Closes #191 .

## Solution Description

This forces the column names for SOAP output to be `object_id` and `source_id`. For other association tables, these fields could still be whatever they want to be.