### PR TITLE
If not resuming, remove intermediate dir.

### DIFF
--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+import warnings
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -35,11 +36,11 @@ class PipelineResumePlan:
         """
         if file_io.directory_has_contents(self.tmp_path):
             if not self.resume:
-                raise ValueError(
-                    f"tmp_path ({self.tmp_path}) contains intermediate files."
-                    " choose a different directory or use --resume flag"
+                self.clean_resume_files()
+            else:
+                warnings.warn(
+                    f"tmp_path ({self.tmp_path}) contains intermediate files; resuming prior progress."
                 )
-            print(f"tmp_path ({self.tmp_path}) contains intermediate files. resuming prior progress.")
         else:
             file_io.make_directory(self.tmp_path, exist_ok=True)
 

--- a/tests/hipscat_import/catalog/test_run_import.py
+++ b/tests/hipscat_import/catalog/test_run_import.py
@@ -67,19 +67,20 @@ def test_resume_dask_runner(
         os.path.join(tmp_path, "resume_catalog", "Norder=0"),
     )
 
-    args = ImportArguments(
-        output_artifact_name="resume_catalog",
-        input_path=small_sky_parts_dir,
-        file_reader="csv",
-        output_path=tmp_path,
-        dask_tmp=tmp_path,
-        tmp_dir=tmp_path,
-        resume_tmp=os.path.join(tmp_path, "tmp"),
-        overwrite=True,
-        highest_healpix_order=0,
-        pixel_threshold=1000,
-        progress_bar=False,
-    )
+    with pytest.warns(UserWarning, match="resuming prior progress"):
+        args = ImportArguments(
+            output_artifact_name="resume_catalog",
+            input_path=small_sky_parts_dir,
+            file_reader="csv",
+            output_path=tmp_path,
+            dask_tmp=tmp_path,
+            tmp_dir=tmp_path,
+            resume_tmp=os.path.join(tmp_path, "tmp"),
+            overwrite=True,
+            highest_healpix_order=0,
+            pixel_threshold=1000,
+            progress_bar=False,
+        )
 
     runner.run(args, dask_client)
 

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -77,14 +77,15 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
 @pytest.mark.dask(timeout=150)
 def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, dask_client):
     """Test that margin cache generation can generate a file for a negative pixel."""
-    args = MarginCacheArguments(
-        margin_threshold=36000.0,
-        input_catalog_path=small_sky_source_catalog,
-        output_path=tmp_path,
-        output_artifact_name="catalog_cache",
-        margin_order=4,
-        progress_bar=False,
-    )
+    with pytest.warns(UserWarning, match="smaller resolution"):
+        args = MarginCacheArguments(
+            margin_threshold=36000.0,
+            input_catalog_path=small_sky_source_catalog,
+            output_path=tmp_path,
+            output_artifact_name="catalog_cache",
+            margin_order=4,
+            progress_bar=False,
+        )
 
     assert args.catalog.catalog_info.ra_column == "source_ra"
 

--- a/tests/hipscat_import/soap/test_soap_resume_plan.py
+++ b/tests/hipscat_import/soap/test_soap_resume_plan.py
@@ -94,13 +94,15 @@ def test_count_keys(small_sky_soap_args):
     ## Mark one done and check that there's one less key to count later.
     Path(small_sky_soap_args.tmp_path, "2_187.csv").touch()
 
-    plan.gather_plan(small_sky_soap_args)
+    with pytest.warns(UserWarning, match="resuming prior progress"):
+        plan.gather_plan(small_sky_soap_args)
     assert len(plan.count_keys) == 13
 
     ## Mark them ALL done and check that there are on keys later.
     plan.touch_stage_done_file(SoapPlan.COUNTING_STAGE)
 
-    plan.gather_plan(small_sky_soap_args)
+    with pytest.warns(UserWarning, match="resuming prior progress"):
+        plan.gather_plan(small_sky_soap_args)
     assert len(plan.count_keys) == 0
 
 
@@ -115,7 +117,8 @@ def test_cached_map_file(small_sky_soap_args):
     cache_map_file = os.path.join(small_sky_soap_args.tmp_path, SoapPlan.SOURCE_MAP_FILE)
     assert os.path.exists(cache_map_file)
 
-    plan = SoapPlan(small_sky_soap_args)
+    with pytest.warns(UserWarning, match="resuming prior progress"):
+        plan = SoapPlan(small_sky_soap_args)
     assert len(plan.count_keys) == 14
 
 

--- a/tests/hipscat_import/test_pipeline_resume_plan.py
+++ b/tests/hipscat_import/test_pipeline_resume_plan.py
@@ -85,8 +85,7 @@ def test_safe_to_resume(tmp_path):
     ## explicitly setting resume=True
     done_file = "action_done"
     plan.touch_stage_done_file(done_file)
-    with pytest.raises(ValueError, match="contains intermediate"):
-        plan.safe_to_resume()
+    plan.safe_to_resume()
 
     ## If we mark as a resuming pipeline, we're safe to resume.
     resuming_plan = PipelineResumePlan(tmp_path=tmp_path, progress_bar=False, resume=True)


### PR DESCRIPTION
## Change Description

Closes #58. Closes #216 .

## Solution Description

If the user specifies `resume=False`, then remove the intermediate directory instead of throwing an error. If we are resuming from prior state, give a warning (and catch this warning in testing, as it's a good indication that we've picked up some prior state and we're using it).