### PR TITLE
Only read required columns in mapping stage.

### DIFF
--- a/src/hipscat_import/catalog/map_reduce.py
+++ b/src/hipscat_import/catalog/map_reduce.py
@@ -45,23 +45,13 @@ def _iterate_input_file(
     if not file_reader:
         raise NotImplementedError("No file reader implemented")
 
-    required_columns = [ra_column, dec_column]
-
     for chunk_number, data in enumerate(file_reader.read(input_file, read_columns=read_columns)):
         if use_hipscat_index:
             if data.index.name == HIPSCAT_ID_COLUMN:
                 mapped_pixels = hipscat_id_to_healpix(data.index, target_order=highest_order)
-            elif HIPSCAT_ID_COLUMN in data.columns:
-                mapped_pixels = hipscat_id_to_healpix(data[HIPSCAT_ID_COLUMN], target_order=highest_order)
             else:
-                raise ValueError(
-                    f"Invalid column names in input file: {HIPSCAT_ID_COLUMN} not in {input_file}"
-                )
+                mapped_pixels = hipscat_id_to_healpix(data[HIPSCAT_ID_COLUMN], target_order=highest_order)
         else:
-            if not all(x in data.columns for x in required_columns):
-                raise ValueError(
-                    f"Invalid column names in input file: {', '.join(required_columns)} not in {input_file}"
-                )
             # Set up the pixel data
             mapped_pixels = hp.ang2pix(
                 2**highest_order,

--- a/src/hipscat_import/catalog/map_reduce.py
+++ b/src/hipscat_import/catalog/map_reduce.py
@@ -39,6 +39,7 @@ def _iterate_input_file(
     ra_column,
     dec_column,
     use_hipscat_index=False,
+    read_columns=None,
 ):
     """Helper function to handle input file reading and healpix pixel calculation"""
     if not file_reader:
@@ -46,7 +47,7 @@ def _iterate_input_file(
 
     required_columns = [ra_column, dec_column]
 
-    for chunk_number, data in enumerate(file_reader.read(input_file)):
+    for chunk_number, data in enumerate(file_reader.read(input_file, read_columns=read_columns)):
         if use_hipscat_index:
             if data.index.name == HIPSCAT_ID_COLUMN:
                 mapped_pixels = hipscat_id_to_healpix(data.index, target_order=highest_order)
@@ -103,8 +104,14 @@ def map_to_pixels(
         FileNotFoundError: if the file does not exist, or is a directory
     """
     histo = pixel_math.empty_histogram(highest_order)
+
+    if use_hipscat_index:
+        read_columns = [HIPSCAT_ID_COLUMN]
+    else:
+        read_columns = [ra_column, dec_column]
+
     for _, _, mapped_pixels in _iterate_input_file(
-        input_file, file_reader, highest_order, ra_column, dec_column, use_hipscat_index
+        input_file, file_reader, highest_order, ra_column, dec_column, use_hipscat_index, read_columns
     ):
         mapped_pixel, count_at_pixel = np.unique(mapped_pixels, return_counts=True)
         mapped_pixel = mapped_pixel.astype(np.int64)

--- a/tests/hipscat_import/catalog/test_map_reduce.py
+++ b/tests/hipscat_import/catalog/test_map_reduce.py
@@ -101,7 +101,7 @@ def test_read_single_fits(tmp_path, formats_fits):
 
 def test_map_headers_wrong(formats_headers_csv):
     """Test loading the a file with non-default headers (without specifying right headers)"""
-    with pytest.raises(ValueError, match="header"):
+    with pytest.raises(ValueError, match="columns expected but not found"):
         mr.map_to_pixels(
             input_file=formats_headers_csv,
             file_reader=get_file_reader("csv"),
@@ -156,7 +156,7 @@ def test_map_with_hipscat_index(tmp_path, formats_dir, small_sky_single_file):
     result = read_partial_histogram(tmp_path, "map_0")
     npt.assert_array_equal(result, expected)
 
-    with pytest.raises(ValueError, match="_hipscat_index not in"):
+    with pytest.raises(ValueError, match="columns expected but not found"):
         mr.map_to_pixels(
             input_file=small_sky_single_file,
             file_reader=get_file_reader("csv"),

--- a/tests/hipscat_import/catalog/test_run_round_trip.py
+++ b/tests/hipscat_import/catalog/test_run_round_trip.py
@@ -389,11 +389,11 @@ def test_import_starr_file(
     class StarrReader(CsvReader):
         """Shallow subclass"""
 
-        def read(self, input_file):
+        def read(self, input_file, read_columns=None):
             files = glob.glob(f"{input_file}/**.starr")
             files.sort()
             for file in files:
-                return super().read(file)
+                return super().read(file, read_columns)
 
     args = ImportArguments(
         output_artifact_name="starr",


### PR DESCRIPTION
## Change Description

Related to Issue #225. 

I wanted to speed up the ECSV reads by only reading the columns we need during the mapping stage. It's relevant for all kinds of file readers, though.