### PR TITLE
Change readthedocs URLs to stable

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
 # For explanation of this file and uses see
 # https://git-scm.com/docs/gitattributes
 # https://developer.lsst.io/git/git-lfs.html#using-git-lfs-enabled-repositories
-# https://lincc-ppt.readthedocs.io/en/latest/practices/git-lfs.html
+# https://lincc-ppt.readthedocs.io/en/stable/practices/git-lfs.html
 #
 # Used by https://github.com/lsst/afwdata.git
 # *.boost filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/pre-commit-ci.yml
+++ b/.github/workflows/pre-commit-ci.yml
@@ -1,6 +1,6 @@
 # This workflow runs pre-commit hooks on pushes and pull requests to main
 # to enforce coding style. To ensure correct configuration, please refer to:
-#  https://lincc-ppt.readthedocs.io/en/latest/practices/ci_precommit.html
+#  https://lincc-ppt.readthedocs.io/en/stable/practices/ci_precommit.html
 name: Run pre-commit hooks
 
 on:

--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -1,7 +1,7 @@
 # This workflow will run daily at 06:45.
 # It will install Python dependencies and run tests with a variety of Python versions.
 # See documentation for help debugging smoke test issues:
-#    https://lincc-ppt.readthedocs.io/en/latest/practices/ci_testing.html#version-culprit
+#    https://lincc-ppt.readthedocs.io/en/stable/practices/ci_testing.html#version-culprit
 
 name: Unit test smoke test
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # hipscat-import
 
-[![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
+[![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/stable/)
 
 [![PyPI](https://img.shields.io/pypi/v/hipscat-import?color=blue&logo=pypi&logoColor=white)](https://pypi.org/project/hipscat-import/)
 [![Conda](https://img.shields.io/conda/vn/conda-forge/hipscat-import.svg?color=blue&logo=condaforge&logoColor=white)](https://anaconda.org/conda-forge/hipscat-import)
@@ -13,21 +13,21 @@
 
 ## HiPSCat import - Utility for ingesting large survey data into HiPSCat structure.
 
-Check out our [ReadTheDocs site](https://hipscat-import.readthedocs.io/en/latest/)
+Check out our [ReadTheDocs site](https://hipscat-import.readthedocs.io/en/stable/)
 for more information on partitioning, installation, and contributing.
 
 See related projects:
 
 * HiPSCat ([on GitHub](https://github.com/astronomy-commons/hipscat))
-  ([on ReadTheDocs](https://hipscat.readthedocs.io/en/latest/))
+  ([on ReadTheDocs](https://hipscat.readthedocs.io/en/stable/))
 * LSDB ([on GitHub](https://github.com/astronomy-commons/lsdb)) 
-  ([on ReadTheDocs](https://lsdb.readthedocs.io/en/latest/))
+  ([on ReadTheDocs](https://lsdb.readthedocs.io/en/stable/))
 
 ## Contributing
 
 [![GitHub issue custom search in repo](https://img.shields.io/github/issues-search/astronomy-commons/hipscat-import?color=purple&label=Good%20first%20issues&query=is%3Aopen%20label%3A%22good%20first%20issue%22)](https://github.com/astronomy-commons/hipscat-import/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 
-See the [contribution guide](https://hipscat-import.readthedocs.io/en/latest/guide/contributing.html)
+See the [contribution guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html)
 for complete installation instructions and contribution best practices.
 
 ## Acknowledgements

--- a/docs/guide/contributing.rst
+++ b/docs/guide/contributing.rst
@@ -55,11 +55,11 @@ Notes:
 2) ``pre-commit install`` will initialize pre-commit for this local repository, so
    that a set of tests will be run prior to completing a local commit. For more
    information, see the Python Project Template documentation on
-   `pre-commit <https://lincc-ppt.readthedocs.io/en/latest/practices/precommit.html>`_.
+   `pre-commit <https://lincc-ppt.readthedocs.io/en/stable/practices/precommit.html>`_.
 3) Installing ``pandoc`` allows you to verify that automatic rendering of Jupyter notebooks
    into documentation for ReadTheDocs works as expected. For more information, see
    the Python Project Template documentation on
-   `Sphinx and Python Notebooks <https://lincc-ppt.readthedocs.io/en/latest/practices/sphinx.html#python-notebooks>`_.
+   `Sphinx and Python Notebooks <https://lincc-ppt.readthedocs.io/en/stable/practices/sphinx.html#python-notebooks>`_.
 
 
 .. tip::


### PR DESCRIPTION
Change links to other LINCC-related readthedocs pages to use en/stable instead of en/latest.

See https://github.com/astronomy-commons/lsdb/issues/260