### PR TITLE
Cross-link the hipscat docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,6 +39,7 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
+    "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "autoapi.extension",
     "nbsphinx",
@@ -66,3 +67,9 @@ copybutton_prompt_text = ">> "
 
 ## lets us suppress the copy button on select code blocks.
 copybutton_selector = "div:not(.no-copybutton) > div.highlight > pre"
+
+# Cross-link hipscat documentation from the API reference:
+# https://docs.readthedocs.io/en/stable/guides/intersphinx.html
+intersphinx_mapping = {
+    "hipscat": ("http://hipscat.readthedocs.io/en/stable/", None),
+}


### PR DESCRIPTION
Add cross-references to the hipscat library in the API documentation.

## Code Quality
- [X] I have read the Contribution Guide
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation