### PR TITLE
Direct to tutorials for public catalogs.

### DIFF
--- a/docs/catalogs/public/index.rst
+++ b/docs/catalogs/public/index.rst
@@ -21,6 +21,8 @@ and provide steps to import those catalogs in case these hints help anyone else.
    sdss
    tic
    zubercal
+   ZTF Bright Transient Survey and New General Catalogue <https://lsdb.readthedocs.io/en/stable/tutorials/ztf_bts-ngc.html>
+   GAIA and DES <https://lsdb.readthedocs.io/en/stable/tutorials/des-gaia.html>
 
 .. tip::
    Want to see more?


### PR DESCRIPTION
Closes #192.

Adds pointer to LSDB tutorials to import and work with a few publicly-available catalogs. 

NB: The links point to stable versions of the LSDB documentation, and the tutorials were recently moved to their new locations. The links won't work until the new version of LSDB is released.