### PR TITLE
Print tracebacks for nested errors.

### DIFF
--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -134,8 +134,21 @@ class PipelineResumePlan:
         ):
             if future.status == "error":
                 some_error = True
-                print(f"{stage_name} task {future.key} failed with message:")
-                print(future.exception())
+                exception = future.exception()
+                trace_strs = [
+                    f"{stage_name} task {future.key} failed with message:",
+                    f"  {type(exception).__name__}: {exception}",
+                    "  Traceback (most recent call last):",
+                ]
+                stack_trace = exception.__traceback__
+                while stack_trace is not None:
+                    filename = stack_trace.tb_frame.f_code.co_filename
+                    method_name = stack_trace.tb_frame.f_code.co_name
+                    line_number = stack_trace.tb_lineno
+                    trace_strs.append(f'    File "{filename}", line {line_number}, in {method_name}')
+                    stack_trace = stack_trace.tb_next
+                print("\n".join(trace_strs))
+
         if some_error:
             raise RuntimeError(f"Some {stage_name} stages failed. See logs for details.")
 


### PR DESCRIPTION
Closes #282 
Closes #273 

Fetches the traceback from the future's error field and prints out the available files, line numbers, and method names.