### PR TITLE
Use preferred string format for globbing.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ dependencies = [
     "pyyaml",
     "tqdm",
     "numpy",
-    "fsspec <= 2024.2.0", # Remove when pyarrow updates to reflect api changes
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -116,7 +116,7 @@ class ImportArguments(RuntimeArguments):
         # Basic checks complete - make more checks and create directories where necessary
         self.input_paths = find_input_paths(
             self.input_path,
-            "**/**.*",
+            "**/*.*",
             self.input_file_list,
             storage_options=self.input_storage_options,
         )

--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -129,7 +129,7 @@ class ResumePlan(PipelineResumePlan):
         remaining_map_files = self.get_remaining_map_keys()
         if len(remaining_map_files) > 0:
             raise RuntimeError(f"{len(remaining_map_files)} map stages did not complete successfully.")
-        histogram_files = file_io.find_files_matching_path(self.tmp_path, self.HISTOGRAMS_DIR, "**.binary")
+        histogram_files = file_io.find_files_matching_path(self.tmp_path, self.HISTOGRAMS_DIR, "*.binary")
         return histogram_files
 
     def read_histogram_from_partials(self, healpix_order):

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -101,7 +101,7 @@ class PipelineResumePlan:
         Returns:
             list of keys taken from files like /resume/path/{key}{extension}
         """
-        result_files = file_io.find_files_matching_path(directory, f"**{extension}")
+        result_files = file_io.find_files_matching_path(directory, f"*{extension}")
         keys = []
         for file_path in result_files:
             result_file_name = file_io.get_basename_from_filepointer(file_path)

--- a/src/hipscat_import/soap/map_reduce.py
+++ b/src/hipscat_import/soap/map_reduce.py
@@ -141,7 +141,7 @@ def combine_partial_results(input_path, output_path, output_storage_options) -> 
     Returns:
         integer that is the sum of all matched num_rows.
     """
-    partial_files = file_io.find_files_matching_path(input_path, "**.csv")
+    partial_files = file_io.find_files_matching_path(input_path, "*.csv")
     partials = []
 
     for partial_file in partial_files:
@@ -194,7 +194,7 @@ def reduce_joins(
         return
     # Find all of the constituent files / source pixels. Create a list of PyArrow Tables from those
     # parquet files. We need to know the schema before we create the ParquetWriter.
-    shard_file_list = file_io.find_files_matching_path(pixel_dir, "source**.parquet")
+    shard_file_list = file_io.find_files_matching_path(pixel_dir, "source*.parquet")
 
     if len(shard_file_list) == 0:
         return

--- a/tests/hipscat_import/catalog/test_run_round_trip.py
+++ b/tests/hipscat_import/catalog/test_run_round_trip.py
@@ -298,7 +298,7 @@ def test_import_starr_file(
         """Shallow subclass"""
 
         def read(self, input_file, read_columns=None):
-            files = glob.glob(f"{input_file}/**.starr")
+            files = glob.glob(f"{input_file}/*.starr")
             files.sort()
             for file in files:
                 return super().read(file, read_columns)


### PR DESCRIPTION
See https://github.com/astronomy-commons/lsdb/issues/294

See https://github.com/astronomy-commons/hipscat/pull/265

The `"**"` path part is only supported in the newest fsspec versions as an "entire path component", so it's ok to say `/match/like/**/` but not `/match/like/**.csv`. This should work with older and newer fsspec versions, and so once the change is released for only newer fsspec versions, this package should be ok.