### PR TITLE
Assorted small doc fixes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -26,7 +26,7 @@ If it fixes an open issue, please link to the issue here. If this PR closes an i
 
 
 ## Code Quality
-- [ ] I have read the Contribution Guide
+- [ ] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
 - [ ] My code follows the code style of this project
 - [ ] My code builds (or compiles) cleanly without any errors or warnings
 - [ ] My code contains relevant comments and necessary documentation

--- a/docs/catalogs/arguments.rst
+++ b/docs/catalogs/arguments.rst
@@ -9,7 +9,7 @@ A minimal arguments block will look something like:
 
 .. code-block:: python
 
-    from hipscat_import.pipeline import ImportArguments
+    from hipscat_import.pipeline.catalog.arguments import ImportArguments
 
     args = ImportArguments(
         sort_columns="ObjectID",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,9 @@ html_css_files = ["custom.css"]
 extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
-    "sphinx.ext.viewcode",
+    # viewcode and autoapi interaction creates some failures. See:
+    # https://github.com/readthedocs/sphinx-autoapi/issues/422
+    # "sphinx.ext.viewcode",
     "sphinx.ext.intersphinx",
     "sphinx_copybutton",
     "autoapi.extension",
@@ -56,6 +58,16 @@ autoapi_dirs = ["../src"]
 autoapi_ignore = ["*/__main__.py", "*/_version.py"]
 autoapi_add_toc_tree_entry = False
 autoapi_member_order = "bysource"
+
+autoapi_options = [
+    "members",
+    "undoc-members",
+    "show-inheritance",
+    "show-module-summary",
+    "special-members",
+    "imported-members",
+    "inherited-members",
+]
 
 napoleon_google_docstring = True
 

--- a/docs/guide/contributing.rst
+++ b/docs/guide/contributing.rst
@@ -40,13 +40,11 @@ create and activate a new environment.
 
 
 Once you have created a new environment, you can install this project for local
-development using the following commands:
+development using the following command:
 
 .. code-block:: console
 
-   >> pip install -e .'[dev]'
-   >> pre-commit install
-   >> conda install pandoc
+   >> source .setup_dev.sh
 
 
 Notes:
@@ -60,29 +58,6 @@ Notes:
    into documentation for ReadTheDocs works as expected. For more information, see
    the Python Project Template documentation on
    `Sphinx and Python Notebooks <https://lincc-ppt.readthedocs.io/en/stable/practices/sphinx.html#python-notebooks>`_.
-
-
-.. tip::
-    Installing on Mac
-
-    ``healpy`` is a very necessary dependency for hipscat libraries at this time, but
-    native prebuilt binaries for healpy on Apple Silicon Macs 
-    `do not yet exist <https://healpy.readthedocs.io/en/latest/install.html#binary-installation-with-pip-recommended-for-most-other-python-users>`_, 
-    so it's recommended to install via conda before proceeding to hipscat-import.
-
-    .. code-block:: console
-
-        >> conda config --add channels conda-forge
-        >> conda install healpy
-        >> git clone https://github.com/astronomy-commons/hipscat-import
-        >> cd hipscat-import
-        >> pip install -e .
-        
-    When installing dev dependencies, make sure to include the single quotes.
-
-    .. code-block:: console
-        
-        >> pip install -e '.[dev]'
 
 Testing
 -------------------------------------------------------------------------------
@@ -131,3 +106,9 @@ Optional - Release a new version
 Once your PR is merged you can create a new release to make your changes available. 
 GitHub's `instructions <https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository>`_ for doing so are here. 
 Use your best judgement when incrementing the version. i.e. is this a major, minor, or patch fix.
+
+Be kind
+-------------------------------------------------------------------------------
+
+You are expected to comply with the 
+`LINCC Frameworks Code of Conduct <https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/>`_`.

--- a/docs/notebooks/estimate_pixel_threshold.ipynb
+++ b/docs/notebooks/estimate_pixel_threshold.ipynb
@@ -1,210 +1,214 @@
 {
-    "cells": [
-     {
-      "cell_type": "markdown",
-      "id": "98af180d",
-      "metadata": {},
-      "source": [
-       "# Estimate pixel threshold\n",
-       "\n",
-       "For best performance, we try to keep catalog parquet files between 200-800MB in size.\n",
-       "\n",
-       "**Background**\n",
-       "\n",
-       "When creating a new catalog through the hipscat-import process, we try to create partitions with approximately the same number of rows per partition. This isn't perfect, because the sky is uneven, but we still try to create smaller-area pixels in more dense areas, and larger-area pixels in less dense areas. We use the argument `pixel_threshold` and will split a partition into smaller healpix pixels until the number of rows is smaller than `pixel_threshold`.\n",
-       "\n",
-       "We do this to increase parallelization of reads and downstream analysis: if the files are around the same size, and operations on each partition take around the same amount of time, we're not as likely to be waiting on a single process to complete for the whole pipeline to complete.\n",
-       "\n",
-       "In addition, a single catalog file should not exceed a couple GB - we're going to need to read the whole thing into memory, so it needs to fit!\n",
-       "\n",
-       "**Objective**\n",
-       "\n",
-       "In this notebook, we'll go over *one* strategy for estimating the `pixel_threshold` argument you can use when importing a new catalog into hipscat format.\n",
-       "\n",
-       "This is not guaranteed to give you optimal results, but it could give you some hints toward *better* results."
-      ]
-     },
-     {
-      "cell_type": "markdown",
-      "id": "eb86458c",
-      "metadata": {},
-      "source": [
-       "## Create a sample parquet file\n",
-       "\n",
-       "The first step is to read in your survey data in its original form, and convert a sample into parquet. This has a few benefits:\n",
-       "- parquet uses compression in various ways, and by creating the sample, we can get a sense of both the overall and field-level compression with real data\n",
-       "- using the importer `FileReader` interface now sets you up for more success when you get around to importing!\n",
-       "\n",
-       "If your data is already in parquet format, just change the `sample_parquet_file` path to an existing file, and don't run the second cell."
-      ]
-     },
-     {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "5dd94480",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-       "### Change this path!!!\n",
-       "import os\n",
-       "import tempfile\n",
-       "\n",
-       "tmp_path = tempfile.TemporaryDirectory()\n",
-       "sample_parquet_file = os.path.join(tmp_path.name, \"sample.parquet\")"
-      ]
-     },
-     {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e6a53db0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-       "from hipscat_import.catalog.file_readers import CsvReader\n",
-       "\n",
-       "### Change this path!!!\n",
-       "input_file = \"../../tests/hipscat_import/data/small_sky/catalog.csv\"\n",
-       "\n",
-       "file_reader = CsvReader(chunksize=5_000)\n",
-       "\n",
-       "next(file_reader.read(input_file)).to_parquet(sample_parquet_file)"
-      ]
-     },
-     {
-      "cell_type": "markdown",
-      "id": "124eb444",
-      "metadata": {},
-      "source": [
-       "## Inspect parquet file and metadata\n",
-       "\n",
-       "Now that we have parsed our survey data into parquet, we can check what the data will look like when it's imported into hipscat format.\n",
-       "\n",
-       "If you're just here to get a naive estimate for your pixel threshold, we'll do that first, then take a look at some other parquet characteristics later for the curious."
-      ]
-     },
-     {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a9f0e279",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-       "import os\n",
-       "import pyarrow.parquet as pq\n",
-       "\n",
-       "sample_file_size = os.path.getsize(sample_parquet_file)\n",
-       "parquet_file = pq.ParquetFile(sample_parquet_file)\n",
-       "num_rows = parquet_file.metadata.num_rows\n",
-       "\n",
-       "## 300MB\n",
-       "ideal_file_small = 300 * 1024 * 1024\n",
-       "## 1G\n",
-       "ideal_file_large = 1024 * 1024 * 1024\n",
-       "\n",
-       "threshold_small = ideal_file_small / sample_file_size * num_rows\n",
-       "threshold_large = ideal_file_large / sample_file_size * num_rows\n",
-       "\n",
-       "print(f\"threshold between {int(threshold_small):_} and {int(threshold_large):_}\")"
-      ]
-     },
-     {
-      "cell_type": "markdown",
-      "id": "23971c38",
-      "metadata": {},
-      "source": [
-       "## Want to see more?\n",
-       "\n",
-       "I'm so glad you're still here! I have more to show you!\n",
-       "\n",
-       "The first step below shows us the file-level metadata, as stored by parquet. The number of columns here SHOULD match your expectations on the number of columns in your survey data.\n",
-       "\n",
-       "The `serialized_size` value is just the size of the total metadata, not the size of the file. "
-      ]
-     },
-     {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "cc402acf",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-       "import pyarrow.parquet as pq\n",
-       "\n",
-       "parquet_file = pq.ParquetFile(sample_parquet_file)\n",
-       "print(parquet_file.metadata)"
-      ]
-     },
-     {
-      "cell_type": "markdown",
-      "id": "7835b6d9",
-      "metadata": {},
-      "source": [
-       "The next step is to look at the column-level metadata. You can check that the on-disk type of each column matches your expectation of the data. Note that for some integer types, the on-disk type may be a smaller int than originally set (e.g. `bitWidth=8` or `16`). This is part of parquet's multi-part compression strategy."
-      ]
-     },
-     {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6ff8fb4d",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-       "print(parquet_file.schema)"
-      ]
-     },
-     {
-      "cell_type": "markdown",
-      "id": "5c2b593b",
-      "metadata": {},
-      "source": [
-       "Parquet will also perform some column-level compression, so not all columns with the same type will take up the same space on disk.\n",
-       "\n",
-       "Below, we inspect the row and column group metadata to show the compressed size of the fields on disk. The last column, `percent`, show the percent of total size taken up by the column.\n",
-       "\n",
-       "You *can* use this to inform which columns you keep when importing a catalog into hipscat format. e.g. if some columns are less useful for your science, and take up a lot of space, maybe leave them out!"
-      ]
-     },
-     {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "dcf152f2",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-       "import numpy as np\n",
-       "import pandas as pd\n",
-       "\n",
-       "num_cols = parquet_file.metadata.num_columns\n",
-       "num_row_groups = parquet_file.metadata.num_row_groups\n",
-       "sizes = np.zeros(num_cols)\n",
-       "\n",
-       "for rg in range(num_row_groups):\n",
-       "    for col in range(num_cols):\n",
-       "        sizes[col] += parquet_file.metadata.row_group(rg).column(col).total_compressed_size\n",
-       "\n",
-       "## This is just an attempt at pretty formatting\n",
-       "percents = [f\"{s/sizes.sum()*100:.1f}\" for s in sizes]\n",
-       "pd.DataFrame({\"name\": parquet_file.schema.names, \"size\": sizes.astype(int), \"percent\": percents}).sort_values(\n",
-       "    \"size\", ascending=False\n",
-       ")"
-      ]
-     }
-    ],
-    "metadata": {
-     "language_info": {
-      "codemirror_mode": {
-       "name": "ipython",
-       "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.9.15"
-     }
-    },
-    "nbformat": 4,
-    "nbformat_minor": 5
-   }
-   
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "98af180d",
+   "metadata": {},
+   "source": [
+    "# Estimate pixel threshold\n",
+    "\n",
+    "For best performance, we try to keep catalog parquet files between 200-800MB in size.\n",
+    "\n",
+    "**Background**\n",
+    "\n",
+    "When creating a new catalog through the hipscat-import process, we try to create partitions with approximately the same number of rows per partition. This isn't perfect, because the sky is uneven, but we still try to create smaller-area pixels in more dense areas, and larger-area pixels in less dense areas. We use the argument `pixel_threshold` and will split a partition into smaller healpix pixels until the number of rows is smaller than `pixel_threshold`.\n",
+    "\n",
+    "We do this to increase parallelization of reads and downstream analysis: if the files are around the same size, and operations on each partition take around the same amount of time, we're not as likely to be waiting on a single process to complete for the whole pipeline to complete.\n",
+    "\n",
+    "In addition, a single catalog file should not exceed a couple GB - we're going to need to read the whole thing into memory, so it needs to fit!\n",
+    "\n",
+    "**Objective**\n",
+    "\n",
+    "In this notebook, we'll go over *one* strategy for estimating the `pixel_threshold` argument you can use when importing a new catalog into hipscat format.\n",
+    "\n",
+    "This is not guaranteed to give you optimal results, but it could give you some hints toward *better* results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "eb86458c",
+   "metadata": {},
+   "source": [
+    "## Create a sample parquet file\n",
+    "\n",
+    "The first step is to read in your survey data in its original form, and convert a sample into parquet. This has a few benefits:\n",
+    "- parquet uses compression in various ways, and by creating the sample, we can get a sense of both the overall and field-level compression with real data\n",
+    "- using the importer `FileReader` interface now sets you up for more success when you get around to importing!\n",
+    "\n",
+    "If your data is already in parquet format, just change the `sample_parquet_file` path to an existing file, and don't run the second cell."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5dd94480",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "### Change this path!!!\n",
+    "import os\n",
+    "import tempfile\n",
+    "\n",
+    "tmp_path = tempfile.TemporaryDirectory()\n",
+    "sample_parquet_file = os.path.join(tmp_path.name, \"sample.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e6a53db0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from hipscat_import.catalog.file_readers import CsvReader\n",
+    "\n",
+    "### Change this path!!!\n",
+    "input_file = \"../../tests/hipscat_import/data/small_sky/catalog.csv\"\n",
+    "\n",
+    "file_reader = CsvReader(chunksize=5_000)\n",
+    "\n",
+    "next(file_reader.read(input_file)).to_parquet(sample_parquet_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "124eb444",
+   "metadata": {},
+   "source": [
+    "## Inspect parquet file and metadata\n",
+    "\n",
+    "Now that we have parsed our survey data into parquet, we can check what the data will look like when it's imported into hipscat format.\n",
+    "\n",
+    "If you're just here to get a naive estimate for your pixel threshold, we'll do that first, then take a look at some other parquet characteristics later for the curious."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a9f0e279",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import pyarrow.parquet as pq\n",
+    "\n",
+    "sample_file_size = os.path.getsize(sample_parquet_file)\n",
+    "parquet_file = pq.ParquetFile(sample_parquet_file)\n",
+    "num_rows = parquet_file.metadata.num_rows\n",
+    "\n",
+    "## 300MB\n",
+    "ideal_file_small = 300 * 1024 * 1024\n",
+    "## 1G\n",
+    "ideal_file_large = 1024 * 1024 * 1024\n",
+    "\n",
+    "threshold_small = ideal_file_small / sample_file_size * num_rows\n",
+    "threshold_large = ideal_file_large / sample_file_size * num_rows\n",
+    "\n",
+    "print(f\"threshold between {int(threshold_small):_} and {int(threshold_large):_}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "23971c38",
+   "metadata": {},
+   "source": [
+    "## Want to see more?\n",
+    "\n",
+    "I'm so glad you're still here! I have more to show you!\n",
+    "\n",
+    "The first step below shows us the file-level metadata, as stored by parquet. The number of columns here SHOULD match your expectations on the number of columns in your survey data.\n",
+    "\n",
+    "The `serialized_size` value is just the size of the total metadata, not the size of the file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc402acf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyarrow.parquet as pq\n",
+    "\n",
+    "parquet_file = pq.ParquetFile(sample_parquet_file)\n",
+    "print(parquet_file.metadata)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7835b6d9",
+   "metadata": {},
+   "source": [
+    "The next step is to look at the column-level metadata. You can check that the on-disk type of each column matches your expectation of the data. Note that for some integer types, the on-disk type may be a smaller int than originally set (e.g. `bitWidth=8` or `16`). This is part of parquet's multi-part compression strategy."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ff8fb4d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(parquet_file.schema)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c2b593b",
+   "metadata": {},
+   "source": [
+    "Parquet will also perform some column-level compression, so not all columns with the same type will take up the same space on disk.\n",
+    "\n",
+    "Below, we inspect the row and column group metadata to show the compressed size of the fields on disk. The last column, `percent`, show the percent of total size taken up by the column.\n",
+    "\n",
+    "You *can* use this to inform which columns you keep when importing a catalog into hipscat format. e.g. if some columns are less useful for your science, and take up a lot of space, maybe leave them out!"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dcf152f2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "num_cols = parquet_file.metadata.num_columns\n",
+    "num_row_groups = parquet_file.metadata.num_row_groups\n",
+    "sizes = np.zeros(num_cols)\n",
+    "\n",
+    "for rg in range(num_row_groups):\n",
+    "    for col in range(num_cols):\n",
+    "        sizes[col] += parquet_file.metadata.row_group(rg).column(col).total_compressed_size\n",
+    "\n",
+    "## This is just an attempt at pretty formatting\n",
+    "percents = [f\"{s/sizes.sum()*100:.1f}\" for s in sizes]\n",
+    "pd.DataFrame({\"name\": parquet_file.schema.names, \"size\": sizes.astype(int), \"percent\": percents}).sort_values(\n",
+    "    \"size\", ascending=False\n",
+    ")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "hipscatenv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.14"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/notebooks/estimate_pixel_threshold.ipynb
+++ b/docs/notebooks/estimate_pixel_threshold.ipynb
@@ -1,209 +1,210 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "id": "98af180d",
-   "metadata": {},
-   "source": [
-    "# Estimate pixel threshold\n",
-    "\n",
-    "For best performance, we try to keep catalog parquet files between 200-800MB in size.\n",
-    "\n",
-    "**Background**\n",
-    "\n",
-    "When creating a new catalog through the hipscat-import process, we try to create partitions with approximately the same number of rows per partition. This isn't perfect, because the sky is uneven, but we still try to create smaller-area pixels in more dense areas, and larger-area pixels in less dense areas. We use the argument `pixel_threshold` and will split a partition into smaller healpix pixels until the number of rows is smaller than `pixel_threshold`.\n",
-    "\n",
-    "We do this to increase parallelization of reads and downstream analysis: if the files are around the same size, and operations on each partition take around the same amount of time, we're not as likely to be waiting on a single process to complete for the whole pipeline to complete.\n",
-    "\n",
-    "In addition, a single catalog file should not exceed a couple GB - we're going to need to read the whole thing into memory, so it needs to fit!\n",
-    "\n",
-    "**Objective**\n",
-    "\n",
-    "In this notebook, we'll go over *one* strategy for estimating the `pixel_threshold` argument you can use when importing a new catalog into hipscat format.\n",
-    "\n",
-    "This is not guaranteed to give you optimal results, but it could give you some hints toward *better* results."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "eb86458c",
-   "metadata": {},
-   "source": [
-    "## Create a sample parquet file\n",
-    "\n",
-    "The first step is to read in your survey data in its original form, and convert a sample into parquet. This has a few benefits:\n",
-    "- parquet uses compression in various ways, and by creating the sample, we can get a sense of both the overall and field-level compression with real dat\n",
-    "- using the importer `FileReader` interface now sets you up for more success when you get around to importing!\n",
-    "\n",
-    "If your data is already in parquet format, just change the `sample_parquet_file` path to an existing file, and don't run the second cell."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5dd94480",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "### Change this path!!!\n",
-    "import os\n",
-    "import tempfile\n",
-    "\n",
-    "tmp_path = tempfile.TemporaryDirectory()\n",
-    "sample_parquet_file = os.path.join(tmp_path.name, \"sample.parquet\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e6a53db0",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from hipscat_import.catalog.file_readers import CsvReader\n",
-    "\n",
-    "### Change this path!!!\n",
-    "input_file = \"../../tests/hipscat_import/data/small_sky/catalog.csv\"\n",
-    "\n",
-    "file_reader = CsvReader(chunksize=5_000)\n",
-    "\n",
-    "next(file_reader.read(input_file)).to_parquet(sample_parquet_file)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "124eb444",
-   "metadata": {},
-   "source": [
-    "## Inspect parquet file and metadata\n",
-    "\n",
-    "Now that we have parsed our survey data into parquet, we can check what the data will look like when it's imported into hipscat format.\n",
-    "\n",
-    "If you're just here to get a naive estimate for your pixel threshold, we'll do that first, then take a look at some other parquet characteristics later for the curious."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a9f0e279",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "import pyarrow.parquet as pq\n",
-    "\n",
-    "sample_file_size = os.path.getsize(sample_parquet_file)\n",
-    "parquet_file = pq.ParquetFile(sample_parquet_file)\n",
-    "num_rows = parquet_file.metadata.num_rows\n",
-    "\n",
-    "## 100MB\n",
-    "ideal_file_small = 100 * 1024 * 1024\n",
-    "## 800MB\n",
-    "ideal_file_large = 800 * 1024 * 1024\n",
-    "\n",
-    "threshold_small = ideal_file_small / sample_file_size * num_rows\n",
-    "threshold_large = ideal_file_large / sample_file_size * num_rows\n",
-    "\n",
-    "print(f\"threshold between {int(threshold_small):_} and {int(threshold_large):_}\")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "23971c38",
-   "metadata": {},
-   "source": [
-    "## Want to see more?\n",
-    "\n",
-    "I'm so glad you're still here! I have more to show you!\n",
-    "\n",
-    "The first step below shows us the file-level metadata, as stored by parquet. The number of columns here SHOULD match your expectations on the number of columns in your survey data.\n",
-    "\n",
-    "The `serialized_size` value is just the size of the total metadata, not the size of the file. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "cc402acf",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import pyarrow.parquet as pq\n",
-    "\n",
-    "parquet_file = pq.ParquetFile(sample_parquet_file)\n",
-    "print(parquet_file.metadata)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "7835b6d9",
-   "metadata": {},
-   "source": [
-    "The next step is to look at the column-level metadata. You can check that the on-disk type of each column matches your expectation of the data. Note that for some integer types, the on-disk type may be a smaller int than originally set (e.g. `bitWidth=8` or `16`). This is part of parquet's multi-part compression strategy."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6ff8fb4d",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(parquet_file.schema)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5c2b593b",
-   "metadata": {},
-   "source": [
-    "Parquet will also perform some column-level compression, so not all columns with the same type will take up the same space on disk.\n",
-    "\n",
-    "Below, we inspect the row and column group metadata to show the compressed size of the fields on disk. The last column, `percent`, show the percent of total size taken up by the column.\n",
-    "\n",
-    "You *can* use this to inform which columns you keep when importing a catalog into hipscat format. e.g. if some columns are less useful for your science, and take up a lot of space, maybe leave them out!"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "dcf152f2",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "\n",
-    "num_cols = parquet_file.metadata.num_columns\n",
-    "num_row_groups = parquet_file.metadata.num_row_groups\n",
-    "sizes = np.zeros(num_cols)\n",
-    "\n",
-    "for rg in range(num_row_groups):\n",
-    "    for col in range(num_cols):\n",
-    "        sizes[col] += parquet_file.metadata.row_group(rg).column(col).total_compressed_size\n",
-    "\n",
-    "## This is just an attempt at pretty formatting\n",
-    "percents = [f\"{s/sizes.sum()*100:.1f}\" for s in sizes]\n",
-    "pd.DataFrame({\"name\": parquet_file.schema.names, \"size\": sizes.astype(int), \"percent\": percents}).sort_values(\n",
-    "    \"size\", ascending=False\n",
-    ")"
-   ]
-  }
- ],
- "metadata": {
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.9.15"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 5
-}
+    "cells": [
+     {
+      "cell_type": "markdown",
+      "id": "98af180d",
+      "metadata": {},
+      "source": [
+       "# Estimate pixel threshold\n",
+       "\n",
+       "For best performance, we try to keep catalog parquet files between 200-800MB in size.\n",
+       "\n",
+       "**Background**\n",
+       "\n",
+       "When creating a new catalog through the hipscat-import process, we try to create partitions with approximately the same number of rows per partition. This isn't perfect, because the sky is uneven, but we still try to create smaller-area pixels in more dense areas, and larger-area pixels in less dense areas. We use the argument `pixel_threshold` and will split a partition into smaller healpix pixels until the number of rows is smaller than `pixel_threshold`.\n",
+       "\n",
+       "We do this to increase parallelization of reads and downstream analysis: if the files are around the same size, and operations on each partition take around the same amount of time, we're not as likely to be waiting on a single process to complete for the whole pipeline to complete.\n",
+       "\n",
+       "In addition, a single catalog file should not exceed a couple GB - we're going to need to read the whole thing into memory, so it needs to fit!\n",
+       "\n",
+       "**Objective**\n",
+       "\n",
+       "In this notebook, we'll go over *one* strategy for estimating the `pixel_threshold` argument you can use when importing a new catalog into hipscat format.\n",
+       "\n",
+       "This is not guaranteed to give you optimal results, but it could give you some hints toward *better* results."
+      ]
+     },
+     {
+      "cell_type": "markdown",
+      "id": "eb86458c",
+      "metadata": {},
+      "source": [
+       "## Create a sample parquet file\n",
+       "\n",
+       "The first step is to read in your survey data in its original form, and convert a sample into parquet. This has a few benefits:\n",
+       "- parquet uses compression in various ways, and by creating the sample, we can get a sense of both the overall and field-level compression with real data\n",
+       "- using the importer `FileReader` interface now sets you up for more success when you get around to importing!\n",
+       "\n",
+       "If your data is already in parquet format, just change the `sample_parquet_file` path to an existing file, and don't run the second cell."
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "5dd94480",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "### Change this path!!!\n",
+       "import os\n",
+       "import tempfile\n",
+       "\n",
+       "tmp_path = tempfile.TemporaryDirectory()\n",
+       "sample_parquet_file = os.path.join(tmp_path.name, \"sample.parquet\")"
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "e6a53db0",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "from hipscat_import.catalog.file_readers import CsvReader\n",
+       "\n",
+       "### Change this path!!!\n",
+       "input_file = \"../../tests/hipscat_import/data/small_sky/catalog.csv\"\n",
+       "\n",
+       "file_reader = CsvReader(chunksize=5_000)\n",
+       "\n",
+       "next(file_reader.read(input_file)).to_parquet(sample_parquet_file)"
+      ]
+     },
+     {
+      "cell_type": "markdown",
+      "id": "124eb444",
+      "metadata": {},
+      "source": [
+       "## Inspect parquet file and metadata\n",
+       "\n",
+       "Now that we have parsed our survey data into parquet, we can check what the data will look like when it's imported into hipscat format.\n",
+       "\n",
+       "If you're just here to get a naive estimate for your pixel threshold, we'll do that first, then take a look at some other parquet characteristics later for the curious."
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "a9f0e279",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "import os\n",
+       "import pyarrow.parquet as pq\n",
+       "\n",
+       "sample_file_size = os.path.getsize(sample_parquet_file)\n",
+       "parquet_file = pq.ParquetFile(sample_parquet_file)\n",
+       "num_rows = parquet_file.metadata.num_rows\n",
+       "\n",
+       "## 300MB\n",
+       "ideal_file_small = 300 * 1024 * 1024\n",
+       "## 1G\n",
+       "ideal_file_large = 1024 * 1024 * 1024\n",
+       "\n",
+       "threshold_small = ideal_file_small / sample_file_size * num_rows\n",
+       "threshold_large = ideal_file_large / sample_file_size * num_rows\n",
+       "\n",
+       "print(f\"threshold between {int(threshold_small):_} and {int(threshold_large):_}\")"
+      ]
+     },
+     {
+      "cell_type": "markdown",
+      "id": "23971c38",
+      "metadata": {},
+      "source": [
+       "## Want to see more?\n",
+       "\n",
+       "I'm so glad you're still here! I have more to show you!\n",
+       "\n",
+       "The first step below shows us the file-level metadata, as stored by parquet. The number of columns here SHOULD match your expectations on the number of columns in your survey data.\n",
+       "\n",
+       "The `serialized_size` value is just the size of the total metadata, not the size of the file. "
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "cc402acf",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "import pyarrow.parquet as pq\n",
+       "\n",
+       "parquet_file = pq.ParquetFile(sample_parquet_file)\n",
+       "print(parquet_file.metadata)"
+      ]
+     },
+     {
+      "cell_type": "markdown",
+      "id": "7835b6d9",
+      "metadata": {},
+      "source": [
+       "The next step is to look at the column-level metadata. You can check that the on-disk type of each column matches your expectation of the data. Note that for some integer types, the on-disk type may be a smaller int than originally set (e.g. `bitWidth=8` or `16`). This is part of parquet's multi-part compression strategy."
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "6ff8fb4d",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "print(parquet_file.schema)"
+      ]
+     },
+     {
+      "cell_type": "markdown",
+      "id": "5c2b593b",
+      "metadata": {},
+      "source": [
+       "Parquet will also perform some column-level compression, so not all columns with the same type will take up the same space on disk.\n",
+       "\n",
+       "Below, we inspect the row and column group metadata to show the compressed size of the fields on disk. The last column, `percent`, show the percent of total size taken up by the column.\n",
+       "\n",
+       "You *can* use this to inform which columns you keep when importing a catalog into hipscat format. e.g. if some columns are less useful for your science, and take up a lot of space, maybe leave them out!"
+      ]
+     },
+     {
+      "cell_type": "code",
+      "execution_count": null,
+      "id": "dcf152f2",
+      "metadata": {},
+      "outputs": [],
+      "source": [
+       "import numpy as np\n",
+       "import pandas as pd\n",
+       "\n",
+       "num_cols = parquet_file.metadata.num_columns\n",
+       "num_row_groups = parquet_file.metadata.num_row_groups\n",
+       "sizes = np.zeros(num_cols)\n",
+       "\n",
+       "for rg in range(num_row_groups):\n",
+       "    for col in range(num_cols):\n",
+       "        sizes[col] += parquet_file.metadata.row_group(rg).column(col).total_compressed_size\n",
+       "\n",
+       "## This is just an attempt at pretty formatting\n",
+       "percents = [f\"{s/sizes.sum()*100:.1f}\" for s in sizes]\n",
+       "pd.DataFrame({\"name\": parquet_file.schema.names, \"size\": sizes.astype(int), \"percent\": percents}).sort_values(\n",
+       "    \"size\", ascending=False\n",
+       ")"
+      ]
+     }
+    ],
+    "metadata": {
+     "language_info": {
+      "codemirror_mode": {
+       "name": "ipython",
+       "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.9.15"
+     }
+    },
+    "nbformat": 4,
+    "nbformat_minor": 5
+   }
+   

--- a/docs/notebooks/unequal_schema.ipynb
+++ b/docs/notebooks/unequal_schema.ipynb
@@ -308,7 +308,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.13"
+   "version": "3.10.14"
   }
  },
  "nbformat": 4,

--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -114,9 +114,7 @@ class CsvReader(InputReader):
         column_names (list[str]): the names of columns if no header is available
         type_map (dict): the data types to use for columns
         parquet_kwargs (dict): additional keyword arguments to use when
-            reading the parquet schema metadata.
-        parquet_kwargs: additional keyword arguments passed to pandas.read_parquet,
-            if reading in a ``schema_file``.
+            reading the parquet schema metadata, passed to pandas.read_parquet.
             See https://pandas.pydata.org/docs/reference/api/pandas.read_parquet.html
         kwargs (dict): additional keyword arguments to use when reading
             the CSV files with pandas.read_csv.

--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -38,6 +38,7 @@ def get_file_reader(
             is available. for fits files, a list of columns to *keep*.
         skip_column_names (list[str]): for fits files, a list of columns to remove.
         type_map (dict): for CSV files, the data types to use for columns
+        kwargs: additional keyword arguments to pass to the underlying file reader.
     """
     if file_format == "csv":
         return CsvReader(
@@ -114,8 +115,12 @@ class CsvReader(InputReader):
         type_map (dict): the data types to use for columns
         parquet_kwargs (dict): additional keyword arguments to use when
             reading the parquet schema metadata.
+        parquet_kwargs: additional keyword arguments passed to pandas.read_parquet,
+            if reading in a ``schema_file``.
+            See https://pandas.pydata.org/docs/reference/api/pandas.read_parquet.html
         kwargs (dict): additional keyword arguments to use when reading
-            the CSV files.
+            the CSV files with pandas.read_csv.
+            See https://pandas.pydata.org/docs/reference/api/pandas.read_csv.html
     """
 
     def __init__(
@@ -187,7 +192,12 @@ class AstropyEcsvReader(InputReader):
     """Reads astropy ascii .ecsv files.
 
     Note that this is NOT a chunked reader. Use caution when reading
-    large ECSV files with this reader."""
+    large ECSV files with this reader.
+
+    Attributes:
+        kwargs: keyword arguments passed to astropy ascii reader.
+            See https://docs.astropy.org/en/stable/api/astropy.io.ascii.read.html#astropy.io.ascii.read
+    """
 
     def __init__(self, **kwargs):
         self.kwargs = kwargs
@@ -227,6 +237,8 @@ class FitsReader(InputReader):
             one of `column_names` or `skip_column_names`
         skip_column_names (list[str]): list of column names to skip. only use
             one of `column_names` or `skip_column_names`
+        kwargs: keyword arguments passed along to astropy.Table.read.
+            See https://docs.astropy.org/en/stable/api/astropy.table.Table.html#astropy.table.Table.read
     """
 
     def __init__(self, chunksize=500_000, column_names=None, skip_column_names=None, **kwargs):
@@ -280,6 +292,8 @@ class ParquetReader(InputReader):
         chunksize (int): number of rows of the file to process at once.
             For large files, this can prevent loading the entire file
             into memory at once.
+        kwargs: arguments to pass along to pyarrow.parquet.ParquetFile.
+            See https://arrow.apache.org/docs/python/generated/pyarrow.parquet.ParquetFile.html
     """
 
     def __init__(self, chunksize=500_000, **kwargs):


### PR DESCRIPTION
- add link to contribution guide and CoC in the pull request template
- add link to CoC in contribution guide
- fix import path in catalog import arguments in argument descriptions page
- set contribution guide to use `.setup_dev.sh` script
- remove mac-specific healpy installation (no longer needed)
- suggest larger threshold for slightly larger leaf parquet files on catalog import
- provider pointers to where input reader `kwargs` will be passed