### PR TITLE
User arguments to retain intermediate files

### DIFF
--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -68,6 +68,13 @@ class ImportArguments(RuntimeArguments):
     """healpix order to use when mapping. will be
     ``highest_healpix_order`` unless a positive value is provided for
     ``constant_healpix_order``"""
+    delete_intermediate_parquet_files: bool = True
+    """should we delete the smaller intermediate parquet files generated in the
+    splitting stage, once the relevant reducing stage is complete?"""
+    delete_resume_log_files: bool = True
+    """should we delete task-level done files once each stage is complete?
+    if False, we will keep all sub-histograms from the mapping stage, and all
+    done marker files at the end of the pipeline."""
     debug_stats_only: bool = False
     """do not perform a map reduce and don't create a new
     catalog. generate the partition info"""
@@ -125,6 +132,7 @@ class ImportArguments(RuntimeArguments):
             progress_bar=self.progress_bar,
             input_paths=self.input_paths,
             tmp_path=self.resume_tmp,
+            delete_resume_log_files=self.delete_resume_log_files,
         )
 
     def to_catalog_info(self, total_rows) -> CatalogInfo:

--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -26,6 +26,10 @@ class ResumePlan(PipelineResumePlan):
     """set of files (and job keys) that have yet to be split"""
     destination_pixel_map: Optional[List[Tuple[HealpixPixel, List[HealpixPixel], str]]] = None
     """Fully resolved map of destination pixels to constituent smaller pixels"""
+    delete_resume_log_files: bool = True
+    """should we delete task-level done files once each stage is complete?
+    if False, we will keep all sub-histograms from the mapping stage, and all
+    done marker files at the end of the pipeline."""
 
     MAPPING_STAGE = "mapping"
     SPLITTING_STAGE = "splitting"
@@ -119,10 +123,11 @@ class ResumePlan(PipelineResumePlan):
                 aggregate_histogram.add(SparseHistogram.from_file(partial_file_name))
 
             aggregate_histogram.to_file(file_name)
-            file_io.remove_directory(
-                file_io.append_paths_to_pointer(self.tmp_path, self.HISTOGRAMS_DIR),
-                ignore_errors=True,
-            )
+            if self.delete_resume_log_files:
+                file_io.remove_directory(
+                    file_io.append_paths_to_pointer(self.tmp_path, self.HISTOGRAMS_DIR),
+                    ignore_errors=True,
+                )
 
         full_histogram = SparseHistogram.from_file(file_name).to_array()
 

--- a/src/hipscat_import/catalog/run_import.py
+++ b/src/hipscat_import/catalog/run_import.py
@@ -98,6 +98,7 @@ def _reduce_pixels(args, destination_pixel_map, client):
                 add_hipscat_index=args.add_hipscat_index,
                 use_schema_file=args.use_schema_file,
                 use_hipscat_index=args.use_hipscat_index,
+                delete_input_files=args.delete_intermediate_parquet_files,
                 storage_options=args.output_storage_options,
             )
         )
@@ -182,5 +183,6 @@ def run(args, client):
         step_progress.update(1)
         io.write_fits_map(args.catalog_path, raw_histogram, storage_options=args.output_storage_options)
         step_progress.update(1)
-        args.resume_plan.clean_resume_files()
+        if args.resume_plan.delete_resume_log_files:
+            args.resume_plan.clean_resume_files()
         step_progress.update(1)


### PR DESCRIPTION
Closes #297 

## Solution Description

Exposes an existing internal testing parameter to keep the intermediate parquet shard files.

In addition, creates new option to keep the intermediate resume logging files.

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)