### PR TITLE
Fail fast on reduce stage failures.

### DIFF
--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -242,7 +242,7 @@ class ResumePlan(PipelineResumePlan):
 
     def wait_for_reducing(self, futures):
         """Wait for reducing futures to complete."""
-        self.wait_for_futures(futures, self.REDUCING_STAGE)
+        self.wait_for_futures(futures, self.REDUCING_STAGE, fail_fast=True)
         remaining_reduce_items = self.get_reduce_items()
         if len(remaining_reduce_items) > 0:
             raise RuntimeError(f"{len(remaining_reduce_items)} reduce stages did not complete successfully.")

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -110,7 +110,7 @@ class PipelineResumePlan:
         """Remove all intermediate files created in execution."""
         file_io.remove_directory(self.tmp_path, ignore_errors=True)
 
-    def wait_for_futures(self, futures, stage_name):
+    def wait_for_futures(self, futures, stage_name, fail_fast=False):
         """Wait for collected futures to complete.
 
         As each future completes, check the returned status.
@@ -118,6 +118,9 @@ class PipelineResumePlan:
         Args:
             futures(List[future]): collected futures
             stage_name(str): name of the stage (e.g. mapping, reducing)
+            fail_fast (bool): if True, we will re-raise the first exception
+                encountered and NOT continue. this may lead to unexpected
+                behavior for in-progress tasks.
         Raises:
             RuntimeError: if any future returns an error status.
         """
@@ -145,6 +148,8 @@ class PipelineResumePlan:
                     trace_strs.append(f'    File "{filename}", line {line_number}, in {method_name}')
                     stack_trace = stack_trace.tb_next
                 print("\n".join(trace_strs))
+                if fail_fast:
+                    raise exception
 
         if some_error:
             raise RuntimeError(f"Some {stage_name} stages failed. See logs for details.")

--- a/tests/hipscat_import/test_pipeline_resume_plan.py
+++ b/tests/hipscat_import/test_pipeline_resume_plan.py
@@ -117,9 +117,30 @@ def test_wait_for_futures(tmp_path, dask_client, capsys):
     with pytest.raises(RuntimeError, match="Some test stages failed"):
         plan.wait_for_futures(futures, "test")
 
-        captured = capsys.readouterr()
-        assert "we are at odds with evens" in captured
-        assert "error_on_even" in captured
+    captured = capsys.readouterr()
+    assert "RuntimeError: we are at odds with evens" in captured.out
+    assert "error_on_even" in captured.out
+
+
+@pytest.mark.dask
+def test_wait_for_futures_fail_fast(tmp_path, dask_client, capsys):
+    """Test that we can wait around for futures to complete.
+
+    Additionally test that relevant parts of the traceback are printed to stdout."""
+    plan = PipelineResumePlan(tmp_path=tmp_path, progress_bar=False, resume=False)
+
+    def error_on_even(argument):
+        """Silly little method used to test futures that fail under predictable conditions"""
+        if argument % 2 == 0:
+            raise RuntimeError("we are at odds with evens")
+
+    futures = [dask_client.submit(error_on_even, 3), dask_client.submit(error_on_even, 4)]
+    with pytest.raises(RuntimeError, match="we are at odds with evens"):
+        plan.wait_for_futures(futures, "test", fail_fast=True)
+
+    captured = capsys.readouterr()
+    assert "we are at odds with evens" in captured.out
+    assert "error_on_even" in captured.out
 
 
 def test_formatted_stage_name():


### PR DESCRIPTION
## Change Description

Closes #300.

Adds code path for the waiting for futures operation to re-raise exception on the first exception encountered. The reducing stage is a little unique, in that a failure in *some* shard indicates that the whole pipeline may be experiencing issues, whereas failures at mapping and splitting are more likely to indicate a problem with an individual file.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [ ] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)