### PR TITLE
Print file name for mapping/splitting failures.

### DIFF
--- a/src/hipscat_import/catalog/map_reduce.py
+++ b/src/hipscat_import/catalog/map_reduce.py
@@ -6,6 +6,7 @@ import healpy as hp
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
+from dask.distributed import print
 from hipscat import pixel_math
 from hipscat.io import FilePointer, file_io, paths
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
@@ -94,22 +95,29 @@ def map_to_pixels(
         ValueError: if the `ra_column` or `dec_column` cannot be found in the input file.
         FileNotFoundError: if the file does not exist, or is a directory
     """
-    histo = SparseHistogram.make_empty(highest_order)
+    try:
+        histo = SparseHistogram.make_empty(highest_order)
 
-    if use_hipscat_index:
-        read_columns = [HIPSCAT_ID_COLUMN]
-    else:
-        read_columns = [ra_column, dec_column]
+        if use_hipscat_index:
+            read_columns = [HIPSCAT_ID_COLUMN]
+        else:
+            read_columns = [ra_column, dec_column]
 
-    for _, _, mapped_pixels in _iterate_input_file(
-        input_file, file_reader, highest_order, ra_column, dec_column, use_hipscat_index, read_columns
-    ):
-        mapped_pixel, count_at_pixel = np.unique(mapped_pixels, return_counts=True)
+        for _, _, mapped_pixels in _iterate_input_file(
+            input_file, file_reader, highest_order, ra_column, dec_column, use_hipscat_index, read_columns
+        ):
+            mapped_pixel, count_at_pixel = np.unique(mapped_pixels, return_counts=True)
 
-        partial = SparseHistogram.make_from_counts(mapped_pixel, count_at_pixel, healpix_order=highest_order)
-        histo.add(partial)
+            partial = SparseHistogram.make_from_counts(
+                mapped_pixel, count_at_pixel, healpix_order=highest_order
+            )
+            histo.add(partial)
 
-    histo.to_file(ResumePlan.partial_histogram_file(tmp_path=resume_path, mapping_key=mapping_key))
+        histo.to_file(ResumePlan.partial_histogram_file(tmp_path=resume_path, mapping_key=mapping_key))
+    except Exception as exception:  # pylint: disable=broad-exception-caught
+        print("Failed MAPPING stage with file ", input_file)
+        print(exception)
+        raise exception
 
 
 def split_pixels(
@@ -142,30 +150,35 @@ def split_pixels(
         ValueError: if the `ra_column` or `dec_column` cannot be found in the input file.
         FileNotFoundError: if the file does not exist, or is a directory
     """
-    for chunk_number, data, mapped_pixels in _iterate_input_file(
-        input_file, file_reader, highest_order, ra_column, dec_column, use_hipscat_index
-    ):
-        aligned_pixels = alignment[mapped_pixels]
-        unique_pixels, unique_inverse = np.unique(aligned_pixels, return_inverse=True)
+    try:
+        for chunk_number, data, mapped_pixels in _iterate_input_file(
+            input_file, file_reader, highest_order, ra_column, dec_column, use_hipscat_index
+        ):
+            aligned_pixels = alignment[mapped_pixels]
+            unique_pixels, unique_inverse = np.unique(aligned_pixels, return_inverse=True)
 
-        for unique_index, [order, pixel, _] in enumerate(unique_pixels):
-            mapped_indexes = np.where(unique_inverse == unique_index)
-            data_indexes = data.index[mapped_indexes[0].tolist()]
+            for unique_index, [order, pixel, _] in enumerate(unique_pixels):
+                mapped_indexes = np.where(unique_inverse == unique_index)
+                data_indexes = data.index[mapped_indexes[0].tolist()]
 
-            filtered_data = data.filter(items=data_indexes, axis=0)
+                filtered_data = data.filter(items=data_indexes, axis=0)
 
-            pixel_dir = get_pixel_cache_directory(cache_shard_path, HealpixPixel(order, pixel))
-            file_io.make_directory(pixel_dir, exist_ok=True)
-            output_file = file_io.append_paths_to_pointer(
-                pixel_dir, f"shard_{splitting_key}_{chunk_number}.parquet"
-            )
-            if _has_named_index(filtered_data):
-                filtered_data.to_parquet(output_file, index=True)
-            else:
-                filtered_data.to_parquet(output_file, index=False)
-            del filtered_data, data_indexes
+                pixel_dir = get_pixel_cache_directory(cache_shard_path, HealpixPixel(order, pixel))
+                file_io.make_directory(pixel_dir, exist_ok=True)
+                output_file = file_io.append_paths_to_pointer(
+                    pixel_dir, f"shard_{splitting_key}_{chunk_number}.parquet"
+                )
+                if _has_named_index(filtered_data):
+                    filtered_data.to_parquet(output_file, index=True)
+                else:
+                    filtered_data.to_parquet(output_file, index=False)
+                del filtered_data, data_indexes
 
-    ResumePlan.splitting_key_done(tmp_path=resume_path, splitting_key=splitting_key)
+        ResumePlan.splitting_key_done(tmp_path=resume_path, splitting_key=splitting_key)
+    except Exception as exception:  # pylint: disable=broad-exception-caught
+        print("Failed SPLITTING stage with file ", input_file)
+        print(exception)
+        raise exception
 
 
 def reduce_pixel_shards(
@@ -227,84 +240,91 @@ def reduce_pixel_shards(
         ValueError: if the number of rows written doesn't equal provided
             `destination_pixel_size`
     """
-    destination_dir = paths.pixel_directory(output_path, destination_pixel_order, destination_pixel_number)
-    file_io.make_directory(destination_dir, exist_ok=True, storage_options=storage_options)
+    try:
+        destination_dir = paths.pixel_directory(
+            output_path, destination_pixel_order, destination_pixel_number
+        )
+        file_io.make_directory(destination_dir, exist_ok=True, storage_options=storage_options)
 
-    destination_file = paths.pixel_catalog_file(
-        output_path, destination_pixel_order, destination_pixel_number
-    )
-
-    schema = None
-    if use_schema_file:
-        schema = file_io.read_parquet_metadata(
-            use_schema_file, storage_options=storage_options
-        ).schema.to_arrow_schema()
-
-    tables = []
-    healpix_pixel = HealpixPixel(destination_pixel_order, destination_pixel_number)
-    pixel_dir = get_pixel_cache_directory(cache_shard_path, healpix_pixel)
-
-    if schema:
-        tables.append(pq.read_table(pixel_dir, schema=schema))
-    else:
-        tables.append(pq.read_table(pixel_dir))
-
-    merged_table = pa.concat_tables(tables)
-
-    rows_written = len(merged_table)
-
-    if rows_written != destination_pixel_size:
-        raise ValueError(
-            "Unexpected number of objects at pixel "
-            f"({healpix_pixel})."
-            f" Expected {destination_pixel_size}, wrote {rows_written}"
+        destination_file = paths.pixel_catalog_file(
+            output_path, destination_pixel_order, destination_pixel_number
         )
 
-    dataframe = merged_table.to_pandas()
-    if sort_columns:
-        dataframe = dataframe.sort_values(sort_columns.split(","))
-    if add_hipscat_index:
-        ## If we had a meaningful index before, preserve it as a column.
-        if _has_named_index(dataframe):
-            dataframe = dataframe.reset_index()
+        schema = None
+        if use_schema_file:
+            schema = file_io.read_parquet_metadata(
+                use_schema_file, storage_options=storage_options
+            ).schema.to_arrow_schema()
 
-        dataframe[HIPSCAT_ID_COLUMN] = pixel_math.compute_hipscat_id(
-            dataframe[ra_column].values,
-            dataframe[dec_column].values,
-        )
-        dataframe = dataframe.set_index(HIPSCAT_ID_COLUMN).sort_index()
-
-        # Adjust the schema to make sure that the _hipscat_index will
-        # be saved as a uint64
-        if schema:
-            pandas_index_column = schema.get_field_index("__index_level_0__")
-            if pandas_index_column != -1:
-                schema = schema.remove(pandas_index_column)
-            schema = schema.insert(0, pa.field(HIPSCAT_ID_COLUMN, pa.uint64()))
-    elif use_hipscat_index:
-        if dataframe.index.name != HIPSCAT_ID_COLUMN:
-            dataframe = dataframe.set_index(HIPSCAT_ID_COLUMN)
-        dataframe = dataframe.sort_index()
-
-    dataframe["Norder"] = np.full(rows_written, fill_value=healpix_pixel.order, dtype=np.uint8)
-    dataframe["Dir"] = np.full(rows_written, fill_value=healpix_pixel.dir, dtype=np.uint64)
-    dataframe["Npix"] = np.full(rows_written, fill_value=healpix_pixel.pixel, dtype=np.uint64)
-
-    if schema:
-        schema = (
-            schema.append(pa.field("Norder", pa.uint8()))
-            .append(pa.field("Dir", pa.uint64()))
-            .append(pa.field("Npix", pa.uint64()))
-        )
-        dataframe.to_parquet(destination_file, schema=schema, storage_options=storage_options)
-    else:
-        dataframe.to_parquet(destination_file, storage_options=storage_options)
-
-    del dataframe, merged_table, tables
-
-    if delete_input_files:
+        tables = []
+        healpix_pixel = HealpixPixel(destination_pixel_order, destination_pixel_number)
         pixel_dir = get_pixel_cache_directory(cache_shard_path, healpix_pixel)
 
-        file_io.remove_directory(pixel_dir, ignore_errors=True, storage_options=storage_options)
+        if schema:
+            tables.append(pq.read_table(pixel_dir, schema=schema))
+        else:
+            tables.append(pq.read_table(pixel_dir))
 
-    ResumePlan.reducing_key_done(tmp_path=resume_path, reducing_key=reducing_key)
+        merged_table = pa.concat_tables(tables)
+
+        rows_written = len(merged_table)
+
+        if rows_written != destination_pixel_size:
+            raise ValueError(
+                "Unexpected number of objects at pixel "
+                f"({healpix_pixel})."
+                f" Expected {destination_pixel_size}, wrote {rows_written}"
+            )
+
+        dataframe = merged_table.to_pandas()
+        if sort_columns:
+            dataframe = dataframe.sort_values(sort_columns.split(","))
+        if add_hipscat_index:
+            ## If we had a meaningful index before, preserve it as a column.
+            if _has_named_index(dataframe):
+                dataframe = dataframe.reset_index()
+
+            dataframe[HIPSCAT_ID_COLUMN] = pixel_math.compute_hipscat_id(
+                dataframe[ra_column].values,
+                dataframe[dec_column].values,
+            )
+            dataframe = dataframe.set_index(HIPSCAT_ID_COLUMN).sort_index()
+
+            # Adjust the schema to make sure that the _hipscat_index will
+            # be saved as a uint64
+            if schema:
+                pandas_index_column = schema.get_field_index("__index_level_0__")
+                if pandas_index_column != -1:
+                    schema = schema.remove(pandas_index_column)
+                schema = schema.insert(0, pa.field(HIPSCAT_ID_COLUMN, pa.uint64()))
+        elif use_hipscat_index:
+            if dataframe.index.name != HIPSCAT_ID_COLUMN:
+                dataframe = dataframe.set_index(HIPSCAT_ID_COLUMN)
+            dataframe = dataframe.sort_index()
+
+        dataframe["Norder"] = np.full(rows_written, fill_value=healpix_pixel.order, dtype=np.uint8)
+        dataframe["Dir"] = np.full(rows_written, fill_value=healpix_pixel.dir, dtype=np.uint64)
+        dataframe["Npix"] = np.full(rows_written, fill_value=healpix_pixel.pixel, dtype=np.uint64)
+
+        if schema:
+            schema = (
+                schema.append(pa.field("Norder", pa.uint8()))
+                .append(pa.field("Dir", pa.uint64()))
+                .append(pa.field("Npix", pa.uint64()))
+            )
+            dataframe.to_parquet(destination_file, schema=schema, storage_options=storage_options)
+        else:
+            dataframe.to_parquet(destination_file, storage_options=storage_options)
+
+        del dataframe, merged_table, tables
+
+        if delete_input_files:
+            pixel_dir = get_pixel_cache_directory(cache_shard_path, healpix_pixel)
+
+            file_io.remove_directory(pixel_dir, ignore_errors=True, storage_options=storage_options)
+
+        ResumePlan.reducing_key_done(tmp_path=resume_path, reducing_key=reducing_key)
+    except Exception as exception:  # pylint: disable=broad-exception-caught
+        print("Failed REDUCING stage for shard: ", destination_pixel_order, destination_pixel_number)
+        print(exception)
+        raise exception

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -225,4 +225,3 @@ def print_task_failure(custom_message, exception):
     except Exception:  # pylint: disable=broad-exception-caught
         pass
     dask_print(exception)
-    raise exception

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -134,22 +134,8 @@ class PipelineResumePlan:
         ):
             if future.status == "error":
                 some_error = True
-                exception = future.exception()
-                trace_strs = [
-                    f"{stage_name} task {future.key} failed with message:",
-                    f"  {type(exception).__name__}: {exception}",
-                    "  Traceback (most recent call last):",
-                ]
-                stack_trace = exception.__traceback__
-                while stack_trace is not None:
-                    filename = stack_trace.tb_frame.f_code.co_filename
-                    method_name = stack_trace.tb_frame.f_code.co_name
-                    line_number = stack_trace.tb_lineno
-                    trace_strs.append(f'    File "{filename}", line {line_number}, in {method_name}')
-                    stack_trace = stack_trace.tb_next
-                print("\n".join(trace_strs))
                 if fail_fast:
-                    raise exception
+                    raise future.exception()
 
         if some_error:
             raise RuntimeError(f"Some {stage_name} stages failed. See logs for details.")

--- a/src/hipscat_import/soap/map_reduce.py
+++ b/src/hipscat_import/soap/map_reduce.py
@@ -5,7 +5,7 @@ from typing import List
 import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
-from dask.distributed import print
+from dask.distributed import print as dask_print
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
 from hipscat.io import FilePointer, file_io, paths
 from hipscat.io.file_io.file_pointer import get_fs, strip_leading_slash_for_pyarrow
@@ -130,9 +130,10 @@ def count_joins(soap_args: SoapArguments, source_pixel: HealpixPixel, object_pix
 
         _write_count_results(soap_args.tmp_path, source_pixel, results)
     except Exception as exception:  # pylint: disable=broad-exception-caught
-        print("Failed COUNTING stage for shard: ", source_pixel)
-        print(exception)
+        dask_print("Failed COUNTING stage for shard: ", source_pixel)
+        dask_print(exception)
         raise exception
+
 
 def combine_partial_results(input_path, output_path, output_storage_options) -> int:
     """Combine many partial CSVs into single partition join info.
@@ -223,7 +224,9 @@ def reduce_joins(
         # Write all of the shards into a single parquet file, one row-group-per-shard.
         starting_catalog_path = FilePointer(str(soap_args.catalog_path))
         destination_dir = paths.pixel_directory(starting_catalog_path, object_pixel.order, object_pixel.pixel)
-        file_io.make_directory(destination_dir, exist_ok=True, storage_options=soap_args.output_storage_options)
+        file_io.make_directory(
+            destination_dir, exist_ok=True, storage_options=soap_args.output_storage_options
+        )
 
         output_file = paths.pixel_catalog_file(starting_catalog_path, object_pixel.order, object_pixel.pixel)
         file_system, output_file = get_fs(
@@ -240,6 +243,6 @@ def reduce_joins(
 
         SoapPlan.reducing_key_done(tmp_path=soap_args.tmp_path, reducing_key=object_key)
     except Exception as exception:  # pylint: disable=broad-exception-caught
-        print("Failed REDUCING stage for shard: ", object_pixel)
-        print(exception)
+        dask_print("Failed REDUCING stage for shard: ", object_pixel)
+        dask_print(exception)
         raise exception

--- a/src/hipscat_import/soap/map_reduce.py
+++ b/src/hipscat_import/soap/map_reduce.py
@@ -5,7 +5,6 @@ from typing import List
 import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
-from dask.distributed import print as dask_print
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
 from hipscat.io import FilePointer, file_io, paths
 from hipscat.io.file_io.file_pointer import get_fs, strip_leading_slash_for_pyarrow
@@ -13,7 +12,7 @@ from hipscat.io.parquet_metadata import get_healpix_pixel_from_metadata
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
 
-from hipscat_import.pipeline_resume_plan import get_pixel_cache_directory
+from hipscat_import.pipeline_resume_plan import get_pixel_cache_directory, print_task_failure
 from hipscat_import.soap.arguments import SoapArguments
 from hipscat_import.soap.resume_plan import SoapPlan
 
@@ -130,8 +129,7 @@ def count_joins(soap_args: SoapArguments, source_pixel: HealpixPixel, object_pix
 
         _write_count_results(soap_args.tmp_path, source_pixel, results)
     except Exception as exception:  # pylint: disable=broad-exception-caught
-        dask_print("Failed COUNTING stage for shard: ", source_pixel)
-        dask_print(exception)
+        print_task_failure(f"Failed COUNTING stage for shard: {source_pixel}", exception)
         raise exception
 
 
@@ -243,6 +241,5 @@ def reduce_joins(
 
         SoapPlan.reducing_key_done(tmp_path=soap_args.tmp_path, reducing_key=object_key)
     except Exception as exception:  # pylint: disable=broad-exception-caught
-        dask_print("Failed REDUCING stage for shard: ", object_pixel)
-        dask_print(exception)
+        print_task_failure(f"Failed REDUCING stage for shard: {object_pixel}", exception)
         raise exception

--- a/tests/hipscat_import/catalog/test_map_reduce.py
+++ b/tests/hipscat_import/catalog/test_map_reduce.py
@@ -58,7 +58,7 @@ def test_read_directory(test_data_dir):
         )
 
 
-def test_read_bad_fileformat(blank_data_file):
+def test_read_bad_fileformat(blank_data_file, capsys):
     """Unsupported file format"""
     with pytest.raises(NotImplementedError):
         mr.map_to_pixels(
@@ -70,6 +70,8 @@ def test_read_bad_fileformat(blank_data_file):
             resume_path="",
             mapping_key="map_0",
         )
+    captured = capsys.readouterr()
+    assert "No file reader implemented" in captured.out
 
 
 def read_partial_histogram(tmp_path, mapping_key):

--- a/tests/hipscat_import/catalog/test_map_reduce.py
+++ b/tests/hipscat_import/catalog/test_map_reduce.py
@@ -248,6 +248,27 @@ def test_map_small_sky_part_order1(tmp_path, small_sky_file0):
     assert (result == expected).all()
 
 
+def test_split_pixels_bad_format(blank_data_file, tmp_path, capsys):
+    """Test loading the a file with non-default headers"""
+    alignment = np.full(12, None)
+    alignment[11] = (0, 11, 131)
+    with pytest.raises(NotImplementedError):
+        mr.split_pixels(
+            input_file=blank_data_file,
+            file_reader=None,
+            highest_order=0,
+            ra_column="ra_mean",
+            dec_column="dec_mean",
+            splitting_key="0",
+            cache_shard_path=tmp_path,
+            resume_path=tmp_path,
+            alignment=alignment,
+        )
+    captured = capsys.readouterr()
+    assert "No file reader implemented" in captured.out
+    os.makedirs(os.path.join(tmp_path, "splitting"))
+
+
 def test_split_pixels_headers(formats_headers_csv, assert_parquet_file_ids, tmp_path):
     """Test loading the a file with non-default headers"""
     os.makedirs(os.path.join(tmp_path, "splitting"))

--- a/tests/hipscat_import/soap/test_soap_map_reduce.py
+++ b/tests/hipscat_import/soap/test_soap_map_reduce.py
@@ -159,3 +159,19 @@ def test_reduce_joins(small_sky_soap_args, soap_intermediate_dir, small_sky_soap
         for row_index in range(14)
     ]
     assert ordered_pixels == list(small_sky_soap_maps.keys())
+
+
+def test_reduce_joins_missing_files(small_sky_soap_args, soap_intermediate_dir, capsys):
+    """Use some previously-computed intermediate files to reduce the joined
+    leaf parquet files into a single parquet file."""
+    temp_path = os.path.join(small_sky_soap_args.tmp_path, "resume", "intermediate")
+    shutil.copytree(
+        soap_intermediate_dir,
+        temp_path,
+    )
+    small_sky_soap_args.tmp_path = temp_path
+
+    with pytest.raises(FileNotFoundError):
+        reduce_joins(small_sky_soap_args, HealpixPixel(0, 11), object_key="0_11")
+    captured = capsys.readouterr()
+    assert "No such file or directory" in captured.out

--- a/tests/hipscat_import/test_pipeline_resume_plan.py
+++ b/tests/hipscat_import/test_pipeline_resume_plan.py
@@ -98,7 +98,7 @@ def test_safe_to_resume(tmp_path):
 
 
 @pytest.mark.dask
-def test_wait_for_futures(tmp_path, dask_client, capsys):
+def test_wait_for_futures(tmp_path, dask_client):
     """Test that we can wait around for futures to complete.
 
     Additionally test that relevant parts of the traceback are printed to stdout."""
@@ -120,7 +120,7 @@ def test_wait_for_futures(tmp_path, dask_client, capsys):
 
 
 @pytest.mark.dask
-def test_wait_for_futures_fail_fast(tmp_path, dask_client, capsys):
+def test_wait_for_futures_fail_fast(tmp_path, dask_client):
     """Test that we can wait around for futures to complete.
 
     Additionally test that relevant parts of the traceback are printed to stdout."""

--- a/tests/hipscat_import/test_pipeline_resume_plan.py
+++ b/tests/hipscat_import/test_pipeline_resume_plan.py
@@ -118,10 +118,6 @@ def test_wait_for_futures(tmp_path, dask_client, capsys):
     with pytest.raises(RuntimeError, match="Some test stages failed"):
         plan.wait_for_futures(futures, "test")
 
-    captured = capsys.readouterr()
-    assert "RuntimeError: we are at odds with evens" in captured.out
-    assert "error_on_even" in captured.out
-
 
 @pytest.mark.dask
 def test_wait_for_futures_fail_fast(tmp_path, dask_client, capsys):
@@ -138,10 +134,6 @@ def test_wait_for_futures_fail_fast(tmp_path, dask_client, capsys):
     futures = [dask_client.submit(error_on_even, 3), dask_client.submit(error_on_even, 4)]
     with pytest.raises(RuntimeError, match="we are at odds with evens"):
         plan.wait_for_futures(futures, "test", fail_fast=True)
-
-    captured = capsys.readouterr()
-    assert "we are at odds with evens" in captured.out
-    assert "error_on_even" in captured.out
 
 
 def test_formatted_stage_name():


### PR DESCRIPTION
## Change Description

Closes #301

Uses dask's distributed print call to log any exception encountered in tasks. This allows for some custom formatting, including the name of the input file, or reference to healpix shard.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation