### PR TITLE
Explicitly depend on scipy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,12 @@ dependencies = [
     "healpy",
     "hipscat >=0.3.0",
     "ipykernel", # Support for Jupyter notebooks
+    "numpy",
     "pandas",
     "pyarrow",
     "pyyaml",
+    "scipy",
     "tqdm",
-    "numpy",
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)


### PR DESCRIPTION
## Change Description

healpy is re-arranging dependencies, and scipy is now an optional dependency. We depend on it, outside of healpy functionality, and should explicitly add to dependency list.