### PR TITLE
Resume functionality for margin cache pipeline.

### DIFF
--- a/src/hipscat_import/margin_cache/margin_cache.py
+++ b/src/hipscat_import/margin_cache/margin_cache.py
@@ -1,107 +1,11 @@
-import pandas as pd
-from dask.distributed import as_completed
-from hipscat import pixel_math
 from hipscat.catalog import PartitionInfo
 from hipscat.io import file_io, parquet_metadata, paths, write_metadata
 from tqdm.auto import tqdm
 
 import hipscat_import.margin_cache.margin_cache_map_reduce as mcmr
+from hipscat_import.margin_cache.margin_cache_resume_plan import MarginCachePlan
 
 # pylint: disable=too-many-locals,too-many-arguments
-
-
-def _find_partition_margin_pixel_pairs(stats, margin_order):
-    """Creates a DataFrame filled with many-to-many connections between
-    the catalog partition pixels and the margin pixels at `margin_order`.
-    """
-    norders = []
-    part_pix = []
-    margin_pix = []
-
-    for healpixel in stats:
-        order = healpixel.order
-        pix = healpixel.pixel
-
-        d_order = margin_order - order
-
-        margins = pixel_math.get_margin(order, pix, d_order)
-
-        for m_p in margins:
-            norders.append(order)
-            part_pix.append(pix)
-            margin_pix.append(m_p)
-
-    margin_pairs_df = pd.DataFrame(
-        zip(norders, part_pix, margin_pix),
-        columns=["partition_order", "partition_pixel", "margin_pixel"],
-    )
-    return margin_pairs_df
-
-
-def _create_margin_directory(stats, output_path, storage_options):
-    """Creates directories for all the catalog partitions."""
-    for healpixel in stats:
-        order = healpixel.order
-        pix = healpixel.pixel
-
-        destination_dir = paths.pixel_directory(output_path, order, pix)
-        file_io.make_directory(destination_dir, exist_ok=True, storage_options=storage_options)
-
-
-def _map_to_margin_shards(client, args, partition_pixels, margin_pairs):
-    """Create all the jobs for mapping partition files into the margin cache."""
-    futures = []
-    mp_future = client.scatter(margin_pairs, broadcast=True)
-    for pix in partition_pixels:
-        partition_file = paths.pixel_catalog_file(args.input_catalog_path, pix.order, pix.pixel)
-        futures.append(
-            client.submit(
-                mcmr.map_pixel_shards,
-                partition_file=partition_file,
-                input_storage_options=args.input_storage_options,
-                margin_pairs=mp_future,
-                margin_threshold=args.margin_threshold,
-                output_path=args.tmp_path,
-                margin_order=args.margin_order,
-                ra_column=args.catalog.catalog_info.ra_column,
-                dec_column=args.catalog.catalog_info.dec_column,
-            )
-        )
-
-    for _ in tqdm(
-        as_completed(futures),
-        desc="Mapping  ",
-        total=len(futures),
-        disable=not args.progress_bar,
-    ):
-        ...
-
-
-def _reduce_margin_shards(client, args, partition_pixels):
-    """Create all the jobs for reducing margin cache shards into singular files"""
-    futures = []
-
-    for pix in partition_pixels:
-        futures.append(
-            client.submit(
-                mcmr.reduce_margin_shards,
-                intermediate_directory=args.tmp_path,
-                output_path=args.catalog_path,
-                output_storage_options=args.output_storage_options,
-                partition_order=pix.order,
-                partition_pixel=pix.pixel,
-                original_catalog_metadata=paths.get_common_metadata_pointer(args.input_catalog_path),
-                input_storage_options=args.input_storage_options,
-            )
-        )
-
-    for _ in tqdm(
-        as_completed(futures),
-        desc="Reducing ",
-        total=len(futures),
-        disable=not args.progress_bar,
-    ):
-        ...
 
 
 def generate_margin_cache(args, client):
@@ -112,26 +16,48 @@ def generate_margin_cache(args, client):
         args (MarginCacheArguments): A valid `MarginCacheArguments` object.
         client (dask.distributed.Client): A dask distributed client object.
     """
-    # determine which order to generate margin pixels for
-    partition_stats = args.catalog.partition_info.get_healpix_pixels()
-
-    # get the negative tree pixels
+    partition_pixels = args.catalog.partition_info.get_healpix_pixels()
     negative_pixels = args.catalog.generate_negative_tree_pixels()
+    combined_pixels = partition_pixels + negative_pixels
+    resume_plan = MarginCachePlan(args, combined_pixels=combined_pixels, partition_pixels=partition_pixels)
 
-    combined_pixels = partition_stats + negative_pixels
+    if not resume_plan.is_mapping_done():
+        futures = []
+        for mapping_key, pix in resume_plan.get_remaining_map_keys():
+            partition_file = paths.pixel_catalog_file(args.input_catalog_path, pix.order, pix.pixel)
+            futures.append(
+                client.submit(
+                    mcmr.map_pixel_shards,
+                    partition_file=partition_file,
+                    mapping_key=mapping_key,
+                    input_storage_options=args.input_storage_options,
+                    margin_pair_file=resume_plan.margin_pair_file,
+                    margin_threshold=args.margin_threshold,
+                    output_path=args.tmp_path,
+                    margin_order=args.margin_order,
+                    ra_column=args.catalog.catalog_info.ra_column,
+                    dec_column=args.catalog.catalog_info.dec_column,
+                )
+            )
+        resume_plan.wait_for_mapping(futures)
 
-    margin_pairs = _find_partition_margin_pixel_pairs(combined_pixels, args.margin_order)
-
-    _create_margin_directory(combined_pixels, args.catalog_path, args.output_storage_options)
-
-    _map_to_margin_shards(
-        client=client,
-        args=args,
-        partition_pixels=partition_stats,
-        margin_pairs=margin_pairs,
-    )
-
-    _reduce_margin_shards(client=client, args=args, partition_pixels=combined_pixels)
+    if not resume_plan.is_reducing_done():
+        futures = []
+        for reducing_key, pix in resume_plan.get_remaining_reduce_keys():
+            futures.append(
+                client.submit(
+                    mcmr.reduce_margin_shards,
+                    intermediate_directory=args.tmp_path,
+                    reducing_key=reducing_key,
+                    output_path=args.catalog_path,
+                    output_storage_options=args.output_storage_options,
+                    partition_order=pix.order,
+                    partition_pixel=pix.pixel,
+                    original_catalog_metadata=paths.get_common_metadata_pointer(args.input_catalog_path),
+                    input_storage_options=args.input_storage_options,
+                )
+            )
+        resume_plan.wait_for_reducing(futures)
 
     with tqdm(total=4, desc="Finishing", disable=not args.progress_bar) as step_progress:
         parquet_metadata.write_parquet_metadata(

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -10,7 +10,7 @@ from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 
 from hipscat_import.margin_cache.margin_cache_resume_plan import MarginCachePlan
-from hipscat_import.pipeline_resume_plan import get_pixel_cache_directory
+from hipscat_import.pipeline_resume_plan import get_pixel_cache_directory, print_task_failure
 
 
 def map_pixel_shards(
@@ -25,29 +25,33 @@ def map_pixel_shards(
     dec_column,
 ):
     """Creates margin cache shards from a source partition file."""
-    data = file_io.load_parquet_to_pandas(partition_file, storage_options=input_storage_options)
+    try:
+        data = file_io.load_parquet_to_pandas(partition_file, storage_options=input_storage_options)
 
-    data["margin_pixel"] = hp.ang2pix(
-        2**margin_order,
-        data[ra_column].values,
-        data[dec_column].values,
-        lonlat=True,
-        nest=True,
-    )
-
-    margin_pairs = pd.read_csv(margin_pair_file)
-    constrained_data = data.reset_index().merge(margin_pairs, on="margin_pixel")
-
-    if len(constrained_data):
-        constrained_data.groupby(["partition_order", "partition_pixel"]).apply(
-            _to_pixel_shard,
-            margin_threshold=margin_threshold,
-            output_path=output_path,
-            ra_column=ra_column,
-            dec_column=dec_column,
+        data["margin_pixel"] = hp.ang2pix(
+            2**margin_order,
+            data[ra_column].values,
+            data[dec_column].values,
+            lonlat=True,
+            nest=True,
         )
 
-    MarginCachePlan.mapping_key_done(output_path, mapping_key)
+        margin_pairs = pd.read_csv(margin_pair_file)
+        constrained_data = data.reset_index().merge(margin_pairs, on="margin_pixel")
+
+        if len(constrained_data):
+            constrained_data.groupby(["partition_order", "partition_pixel"]).apply(
+                _to_pixel_shard,
+                margin_threshold=margin_threshold,
+                output_path=output_path,
+                ra_column=ra_column,
+                dec_column=dec_column,
+            )
+
+        MarginCachePlan.mapping_key_done(output_path, mapping_key)
+    except Exception as exception:  # pylint: disable=broad-exception-caught
+        print_task_failure(f"Failed MAPPING stage for pixel: {mapping_key}", exception)
+        raise exception
 
 
 def _to_pixel_shard(data, margin_threshold, output_path, ra_column, dec_column):
@@ -117,29 +121,37 @@ def reduce_margin_shards(
     input_storage_options,
 ):
     """Reduce all partition pixel directories into a single file"""
-    shard_dir = get_pixel_cache_directory(
-        intermediate_directory, HealpixPixel(partition_order, partition_pixel)
-    )
-    if file_io.does_file_or_directory_exist(shard_dir):
-        data = ds.dataset(shard_dir, format="parquet")
-        full_df = data.to_table().to_pandas()
-        margin_cache_dir = paths.pixel_directory(output_path, partition_order, partition_pixel)
-        file_io.make_directory(margin_cache_dir, exist_ok=True, storage_options=output_storage_options)
+    try:
+        shard_dir = get_pixel_cache_directory(
+            intermediate_directory, HealpixPixel(partition_order, partition_pixel)
+        )
+        if file_io.does_file_or_directory_exist(shard_dir):
+            data = ds.dataset(shard_dir, format="parquet")
+            full_df = data.to_table().to_pandas()
+            margin_cache_dir = paths.pixel_directory(output_path, partition_order, partition_pixel)
+            file_io.make_directory(margin_cache_dir, exist_ok=True, storage_options=output_storage_options)
 
-        if len(full_df):
-            schema = file_io.read_parquet_metadata(
-                original_catalog_metadata, storage_options=input_storage_options
-            ).schema.to_arrow_schema()
+            if len(full_df):
+                schema = file_io.read_parquet_metadata(
+                    original_catalog_metadata, storage_options=input_storage_options
+                ).schema.to_arrow_schema()
 
-            schema = (
-                schema.append(pa.field("margin_Norder", pa.uint8()))
-                .append(pa.field("margin_Dir", pa.uint64()))
-                .append(pa.field("margin_Npix", pa.uint64()))
-            )
+                schema = (
+                    schema.append(pa.field("margin_Norder", pa.uint8()))
+                    .append(pa.field("margin_Dir", pa.uint64()))
+                    .append(pa.field("margin_Npix", pa.uint64()))
+                )
 
-            margin_cache_file_path = paths.pixel_catalog_file(output_path, partition_order, partition_pixel)
+                margin_cache_file_path = paths.pixel_catalog_file(
+                    output_path, partition_order, partition_pixel
+                )
 
-            full_df.to_parquet(margin_cache_file_path, schema=schema, storage_options=output_storage_options)
-            file_io.remove_directory(shard_dir)
+                full_df.to_parquet(
+                    margin_cache_file_path, schema=schema, storage_options=output_storage_options
+                )
+                file_io.remove_directory(shard_dir)
 
-    MarginCachePlan.reducing_key_done(intermediate_directory, reducing_key)
+        MarginCachePlan.reducing_key_done(intermediate_directory, reducing_key)
+    except Exception as exception:  # pylint: disable=broad-exception-caught
+        print_task_failure(f"Failed REDUCING stage for pixel: {reducing_key}", exception)
+        raise exception

--- a/src/hipscat_import/margin_cache/margin_cache_resume_plan.py
+++ b/src/hipscat_import/margin_cache/margin_cache_resume_plan.py
@@ -1,0 +1,176 @@
+"""Utility to hold the pipeline execution plan."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List
+
+import pandas as pd
+from hipscat import pixel_math
+from hipscat.io import file_io, paths
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
+from tqdm.auto import tqdm
+
+from hipscat_import.margin_cache.margin_cache_arguments import MarginCacheArguments
+from hipscat_import.pipeline_resume_plan import PipelineResumePlan
+
+
+@dataclass
+class MarginCachePlan(PipelineResumePlan):
+    """Container class for holding the state of each file in the pipeline plan."""
+
+    margin_pair_file: str | None = None
+    partition_pixels: List[HealpixPixel] = field(default_factory=list)
+    combined_pixels: List[HealpixPixel] = field(default_factory=list)
+
+    MAPPING_STAGE = "mapping"
+    REDUCING_STAGE = "reducing"
+    MARGIN_PAIR_FILE = "margin_pair.csv"
+
+    def __init__(self, args: MarginCacheArguments, combined_pixels, partition_pixels):
+        if not args.tmp_path:  # pragma: no cover (not reachable, but required for mypy)
+            raise ValueError("tmp_path is required")
+        super().__init__(
+            resume=args.resume,
+            progress_bar=args.progress_bar,
+            tmp_path=args.tmp_path,
+        )
+        self.combined_pixels = combined_pixels
+        self.partition_pixels = partition_pixels
+        self._gather_plan(args)
+
+    def _gather_plan(self, args):
+        """Initialize the plan."""
+        with tqdm(
+            total=3, desc=self.get_formatted_stage_name("Planning"), disable=not self.progress_bar
+        ) as step_progress:
+            ## Make sure it's safe to use existing resume state.
+            super().safe_to_resume()
+            mapping_done = self.is_mapping_done()
+            reducing_done = self.is_reducing_done()
+            if reducing_done and (not mapping_done):
+                raise ValueError("mapping must be complete before reducing")
+            step_progress.update(1)
+
+            self.margin_pair_file = file_io.append_paths_to_pointer(self.tmp_path, self.MARGIN_PAIR_FILE)
+            if not file_io.does_file_or_directory_exist(self.margin_pair_file):
+                margin_pairs = _find_partition_margin_pixel_pairs(self.combined_pixels, args.margin_order)
+                margin_pairs.to_csv(self.margin_pair_file)
+            step_progress.update(1)
+
+            file_io.make_directory(
+                file_io.append_paths_to_pointer(self.tmp_path, self.MAPPING_STAGE),
+                exist_ok=True,
+            )
+            file_io.make_directory(
+                file_io.append_paths_to_pointer(self.tmp_path, self.REDUCING_STAGE),
+                exist_ok=True,
+            )
+            _create_margin_directory(self.combined_pixels, args.catalog_path, args.output_storage_options)
+
+            step_progress.update(1)
+
+    @classmethod
+    def mapping_key_done(cls, tmp_path, mapping_key: str):
+        """Mark a single mapping task as done
+
+        Args:
+            tmp_path (str): where to write intermediate resume files.
+            mapping_key (str): unique string for each mapping task (e.g. "map_1_24")
+        """
+        cls.touch_key_done_file(tmp_path, cls.MAPPING_STAGE, mapping_key)
+
+    def wait_for_mapping(self, futures):
+        """Wait for mapping stage futures to complete."""
+        self.wait_for_futures(futures, self.MAPPING_STAGE)
+        remaining_pixels_to_map = self.get_remaining_map_keys()
+        if len(remaining_pixels_to_map) > 0:
+            raise RuntimeError(
+                f"{len(remaining_pixels_to_map)} mapping stages did not complete successfully."
+            )
+        self.touch_stage_done_file(self.MAPPING_STAGE)
+
+    def is_mapping_done(self) -> bool:
+        """Are there sources left to count?"""
+        return self.done_file_exists(self.MAPPING_STAGE)
+
+    def get_remaining_map_keys(self):
+        """Fetch a tuple for each pixel/partition left to map."""
+        map_keys = set(self.read_done_keys(self.MAPPING_STAGE))
+        return [
+            (f"{hp_pixel.order}_{hp_pixel.pixel}", hp_pixel)
+            for hp_pixel in self.partition_pixels
+            if f"{hp_pixel.order}_{hp_pixel.pixel}" not in map_keys
+        ]
+
+    @classmethod
+    def reducing_key_done(cls, tmp_path, reducing_key: str):
+        """Mark a single reducing task as done
+
+        Args:
+            tmp_path (str): where to write intermediate resume files.
+            reducing_key (str): unique string for each reducing task (e.g. "3_57")
+        """
+        cls.touch_key_done_file(tmp_path, cls.REDUCING_STAGE, reducing_key)
+
+    def get_remaining_reduce_keys(self):
+        """Fetch a tuple for each object catalog pixel to reduce."""
+        reduced_keys = set(self.read_done_keys(self.REDUCING_STAGE))
+        reduce_items = [
+            (f"{hp_pixel.order}_{hp_pixel.pixel}", hp_pixel)
+            for hp_pixel in self.combined_pixels
+            if f"{hp_pixel.order}_{hp_pixel.pixel}" not in reduced_keys
+        ]
+        return reduce_items
+
+    def is_reducing_done(self) -> bool:
+        """Are there partitions left to reduce?"""
+        return self.done_file_exists(self.REDUCING_STAGE)
+
+    def wait_for_reducing(self, futures):
+        """Wait for reducing stage futures to complete."""
+        self.wait_for_futures(futures, self.REDUCING_STAGE)
+        remaining_sources_to_reduce = self.get_remaining_reduce_keys()
+        if len(remaining_sources_to_reduce) > 0:
+            raise RuntimeError(
+                f"{len(remaining_sources_to_reduce)} reducing stages did not complete successfully."
+            )
+        self.touch_stage_done_file(self.REDUCING_STAGE)
+
+
+def _find_partition_margin_pixel_pairs(stats, margin_order):
+    """Creates a DataFrame filled with many-to-many connections between
+    the catalog partition pixels and the margin pixels at `margin_order`.
+    """
+    norders = []
+    part_pix = []
+    margin_pix = []
+
+    for healpixel in stats:
+        order = healpixel.order
+        pix = healpixel.pixel
+
+        d_order = margin_order - order
+
+        margins = pixel_math.get_margin(order, pix, d_order)
+
+        for m_p in margins:
+            norders.append(order)
+            part_pix.append(pix)
+            margin_pix.append(m_p)
+
+    margin_pairs_df = pd.DataFrame(
+        zip(norders, part_pix, margin_pix),
+        columns=["partition_order", "partition_pixel", "margin_pixel"],
+    )
+    return margin_pairs_df
+
+
+def _create_margin_directory(stats, output_path, storage_options):
+    """Creates directories for all the catalog partitions."""
+    for healpixel in stats:
+        order = healpixel.order
+        pix = healpixel.pixel
+
+        destination_dir = paths.pixel_directory(output_path, order, pix)
+        file_io.make_directory(destination_dir, exist_ok=True, storage_options=storage_options)

--- a/src/hipscat_import/margin_cache/margin_cache_resume_plan.py
+++ b/src/hipscat_import/margin_cache/margin_cache_resume_plan.py
@@ -7,7 +7,7 @@ from typing import List
 
 import pandas as pd
 from hipscat import pixel_math
-from hipscat.io import file_io, paths
+from hipscat.io import file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from tqdm.auto import tqdm
 

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -6,12 +6,10 @@ import pandas as pd
 import pytest
 from hipscat.catalog import PartitionInfo
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset
-from hipscat.io import file_io, paths
+from hipscat.io import paths
 
 import hipscat_import.margin_cache.margin_cache as mc
 from hipscat_import.margin_cache.margin_cache_arguments import MarginCacheArguments
-
-# pylint: disable=protected-access
 
 
 @pytest.mark.dask(timeout=150)
@@ -99,66 +97,3 @@ def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, da
     negative_data = pd.read_parquet(negative_test_file)
 
     assert len(negative_data) > 0
-
-
-def test_partition_margin_pixel_pairs(small_sky_source_catalog, tmp_path):
-    """Ensure partition_margin_pixel_pairs can generate main partition pixels."""
-    args = MarginCacheArguments(
-        margin_threshold=5.0,
-        input_catalog_path=small_sky_source_catalog,
-        output_path=tmp_path,
-        output_artifact_name="catalog_cache",
-    )
-
-    margin_pairs = mc._find_partition_margin_pixel_pairs(
-        args.catalog.partition_info.get_healpix_pixels(), args.margin_order
-    )
-
-    expected = np.array([725, 733, 757, 765, 727, 735, 759, 767, 469, 192])
-
-    npt.assert_array_equal(margin_pairs.iloc[:10]["margin_pixel"], expected)
-    assert len(margin_pairs) == 196
-
-
-def test_partition_margin_pixel_pairs_negative(small_sky_source_catalog, tmp_path):
-    """Ensure partition_margin_pixel_pairs can generate negative tree pixels."""
-    args = MarginCacheArguments(
-        margin_threshold=5.0,
-        input_catalog_path=small_sky_source_catalog,
-        output_path=tmp_path,
-        output_artifact_name="catalog_cache",
-    )
-
-    partition_stats = args.catalog.partition_info.get_healpix_pixels()
-    negative_pixels = args.catalog.generate_negative_tree_pixels()
-    combined_pixels = partition_stats + negative_pixels
-
-    margin_pairs = mc._find_partition_margin_pixel_pairs(combined_pixels, args.margin_order)
-
-    expected_order = 0
-    expected_pixel = 10
-    expected = np.array([490, 704, 712, 736, 744, 706, 714, 738, 746, 512])
-
-    assert margin_pairs.iloc[-1]["partition_order"] == expected_order
-    assert margin_pairs.iloc[-1]["partition_pixel"] == expected_pixel
-    npt.assert_array_equal(margin_pairs.iloc[-10:]["margin_pixel"], expected)
-    assert len(margin_pairs) == 536
-
-
-def test_create_margin_directory(small_sky_source_catalog, tmp_path):
-    """Ensure create_margin_directory works on main partition_pixels"""
-    args = MarginCacheArguments(
-        margin_threshold=5.0,
-        input_catalog_path=small_sky_source_catalog,
-        output_path=tmp_path,
-        output_artifact_name="catalog_cache",
-    )
-
-    mc._create_margin_directory(
-        stats=args.catalog.partition_info.get_healpix_pixels(),
-        output_path=args.catalog_path,
-        storage_options=None,
-    )
-
-    output = file_io.append_paths_to_pointer(args.catalog_path, "Norder=0", "Dir=0")
-    assert file_io.does_file_or_directory_exist(output)

--- a/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
@@ -77,6 +77,7 @@ def test_reduce_margin_shards(tmp_path, basic_data_shard_df):
     shard_dir = paths.pixel_directory(partition_dir, 1, 21)
 
     os.makedirs(shard_dir)
+    os.makedirs(os.path.join(intermediate_dir, "reducing"))
 
     first_shard_path = paths.pixel_catalog_file(partition_dir, 1, 0)
     second_shard_path = paths.pixel_catalog_file(partition_dir, 1, 1)
@@ -118,6 +119,7 @@ def test_reduce_margin_shards(tmp_path, basic_data_shard_df):
 
     margin_cache_map_reduce.reduce_margin_shards(
         intermediate_dir,
+        "1_21",
         tmp_path,
         None,
         1,

--- a/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
@@ -70,8 +70,27 @@ def test_to_pixel_shard_polar(tmp_path, polar_data_shard_df):
     validate_result_dataframe(path, 360)
 
 
-@pytest.mark.dask
-def test_reduce_margin_shards(tmp_path, basic_data_shard_df):
+def test_map_pixel_shards_error(tmp_path, capsys):
+    """Test error behavior on reduce stage. e.g. by not creating the original
+    catalog parquet files."""
+    with pytest.raises(FileNotFoundError):
+        margin_cache_map_reduce.map_pixel_shards(
+            paths.pixel_catalog_file(tmp_path, 1, 0),
+            mapping_key="1_21",
+            input_storage_options=None,
+            margin_pair_file="",
+            margin_threshold=10,
+            output_path=tmp_path,
+            margin_order=4,
+            ra_column="ra",
+            dec_column="dec",
+        )
+
+    captured = capsys.readouterr()
+    assert "No such file or directory" in captured.out
+
+
+def test_reduce_margin_shards(tmp_path):
     intermediate_dir = os.path.join(tmp_path, "intermediate")
     partition_dir = get_pixel_cache_directory(intermediate_dir, HealpixPixel(1, 21))
     shard_dir = paths.pixel_directory(partition_dir, 1, 21)
@@ -132,3 +151,34 @@ def test_reduce_margin_shards(tmp_path, basic_data_shard_df):
 
     validate_result_dataframe(result_path, 720)
     assert not os.path.exists(shard_dir)
+
+
+def test_reduce_margin_shards_error(tmp_path, basic_data_shard_df, capsys):
+    """Test error behavior on reduce stage. e.g. by not creating the original
+    catalog metadata."""
+    intermediate_dir = os.path.join(tmp_path, "intermediate")
+    partition_dir = get_pixel_cache_directory(intermediate_dir, HealpixPixel(1, 21))
+    shard_dir = paths.pixel_directory(partition_dir, 1, 21)
+    os.makedirs(shard_dir)
+    os.makedirs(os.path.join(intermediate_dir, "reducing"))
+
+    # Don't write anything at the metadata path!
+    schema_path = os.path.join(tmp_path, "metadata.parquet")
+
+    basic_data_shard_df.to_parquet(paths.pixel_catalog_file(partition_dir, 1, 0))
+    basic_data_shard_df.to_parquet(paths.pixel_catalog_file(partition_dir, 1, 1))
+
+    with pytest.raises(FileNotFoundError):
+        margin_cache_map_reduce.reduce_margin_shards(
+            intermediate_dir,
+            "1_21",
+            tmp_path,
+            None,
+            1,
+            21,
+            original_catalog_metadata=schema_path,
+            input_storage_options=None,
+        )
+
+    captured = capsys.readouterr()
+    assert "No such file or directory" in captured.out

--- a/tests/hipscat_import/margin_cache/test_margin_cache_resume_plan.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_resume_plan.py
@@ -1,7 +1,6 @@
 import numpy as np
 import numpy.testing as npt
 import pytest
-from hipscat.io import file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 from hipscat_import.margin_cache.margin_cache_arguments import MarginCacheArguments

--- a/tests/hipscat_import/margin_cache/test_margin_cache_resume_plan.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_resume_plan.py
@@ -1,0 +1,151 @@
+import numpy as np
+import numpy.testing as npt
+import pytest
+from hipscat.io import file_io
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
+
+from hipscat_import.margin_cache.margin_cache_arguments import MarginCacheArguments
+from hipscat_import.margin_cache.margin_cache_resume_plan import (
+    MarginCachePlan,
+    _create_margin_directory,
+    _find_partition_margin_pixel_pairs,
+)
+
+# pylint: disable=protected-access
+
+
+@pytest.fixture
+def small_sky_margin_args(tmp_path, small_sky_source_catalog):
+    return MarginCacheArguments(
+        margin_threshold=5.0,
+        input_catalog_path=small_sky_source_catalog,
+        output_path=tmp_path,
+        output_artifact_name="catalog_cache",
+        progress_bar=False,
+        resume=True,
+    )
+
+
+def test_done_checks(small_sky_margin_args):
+    """Verify that done files imply correct pipeline execution order:
+    mapping > reducing
+    """
+    pixels = [HealpixPixel(0, 11)]
+    plan = MarginCachePlan(small_sky_margin_args, pixels, pixels)
+    plan.touch_stage_done_file(MarginCachePlan.REDUCING_STAGE)
+
+    with pytest.raises(ValueError, match="before reducing"):
+        plan._gather_plan(small_sky_margin_args)
+
+    plan.touch_stage_done_file(MarginCachePlan.MAPPING_STAGE)
+    plan._gather_plan(small_sky_margin_args)
+    assert plan.is_mapping_done()
+    assert plan.is_reducing_done()
+
+    plan.clean_resume_files()
+
+    plan = MarginCachePlan(small_sky_margin_args, pixels, pixels)
+    plan.touch_stage_done_file(MarginCachePlan.MAPPING_STAGE)
+    plan._gather_plan(small_sky_margin_args)
+
+    assert plan.is_mapping_done()
+    assert not plan.is_reducing_done()
+
+
+def never_fails():
+    """Method never fails, but never marks intermediate success file."""
+    return
+
+
+@pytest.mark.dask
+def test_some_map_task_failures(small_sky_margin_args, dask_client):
+    """Test that we only consider map stage successful if all done files are written"""
+    pixels = [HealpixPixel(0, 10), HealpixPixel(0, 11)]
+    plan = MarginCachePlan(small_sky_margin_args, pixels, pixels)
+
+    ## Method doesn't FAIL, but it doesn't write out the done file either.
+    ## Since the intermediate files aren't found, we throw an error.
+    futures = [dask_client.submit(never_fails)]
+    with pytest.raises(RuntimeError, match="2 mapping stages"):
+        plan.wait_for_mapping(futures)
+
+    MarginCachePlan.touch_key_done_file(plan.tmp_path, MarginCachePlan.MAPPING_STAGE, "0_11")
+
+    ## Method succeeds, but only *ONE* done file is present.
+    futures = [dask_client.submit(never_fails)]
+    with pytest.raises(RuntimeError, match="1 mapping stage"):
+        plan.wait_for_mapping(futures)
+
+    MarginCachePlan.touch_key_done_file(plan.tmp_path, MarginCachePlan.MAPPING_STAGE, "0_10")
+
+    ## Method succeeds, *and* done files are present.
+    futures = [dask_client.submit(never_fails)]
+    plan.wait_for_mapping(futures)
+
+
+@pytest.mark.dask
+def test_some_reducing_task_failures(small_sky_margin_args, dask_client):
+    """Test that we only consider reduce stage successful if all done files are written"""
+    pixels = [HealpixPixel(0, 10), HealpixPixel(0, 11)]
+    plan = MarginCachePlan(small_sky_margin_args, pixels, pixels)
+
+    ## Method doesn't FAIL, but it doesn't write out the done file either.
+    ## Since the intermediate files aren't found, we throw an error.
+    futures = [dask_client.submit(never_fails)]
+    with pytest.raises(RuntimeError, match="2 reducing stages"):
+        plan.wait_for_reducing(futures)
+
+    MarginCachePlan.touch_key_done_file(plan.tmp_path, MarginCachePlan.REDUCING_STAGE, "0_11")
+
+    ## Method succeeds, but only *ONE* done file is present.
+    futures = [dask_client.submit(never_fails)]
+    with pytest.raises(RuntimeError, match="1 reducing stage"):
+        plan.wait_for_reducing(futures)
+
+    MarginCachePlan.touch_key_done_file(plan.tmp_path, MarginCachePlan.REDUCING_STAGE, "0_10")
+
+    ## Method succeeds, *and* done files are present.
+    futures = [dask_client.submit(never_fails)]
+    plan.wait_for_reducing(futures)
+
+
+def test_partition_margin_pixel_pairs(small_sky_margin_args):
+    """Ensure partition_margin_pixel_pairs can generate main partition pixels."""
+    margin_pairs = _find_partition_margin_pixel_pairs(
+        small_sky_margin_args.catalog.partition_info.get_healpix_pixels(), small_sky_margin_args.margin_order
+    )
+
+    expected = np.array([725, 733, 757, 765, 727, 735, 759, 767, 469, 192])
+
+    npt.assert_array_equal(margin_pairs.iloc[:10]["margin_pixel"], expected)
+    assert len(margin_pairs) == 196
+
+
+def test_partition_margin_pixel_pairs_negative(small_sky_margin_args):
+    """Ensure partition_margin_pixel_pairs can generate negative tree pixels."""
+    partition_stats = small_sky_margin_args.catalog.partition_info.get_healpix_pixels()
+    negative_pixels = small_sky_margin_args.catalog.generate_negative_tree_pixels()
+    combined_pixels = partition_stats + negative_pixels
+
+    margin_pairs = _find_partition_margin_pixel_pairs(combined_pixels, small_sky_margin_args.margin_order)
+
+    expected_order = 0
+    expected_pixel = 10
+    expected = np.array([490, 704, 712, 736, 744, 706, 714, 738, 746, 512])
+
+    assert margin_pairs.iloc[-1]["partition_order"] == expected_order
+    assert margin_pairs.iloc[-1]["partition_pixel"] == expected_pixel
+    npt.assert_array_equal(margin_pairs.iloc[-10:]["margin_pixel"], expected)
+    assert len(margin_pairs) == 536
+
+
+def test_create_margin_directory(small_sky_margin_args):
+    """Ensure create_margin_directory works on main partition_pixels"""
+    _create_margin_directory(
+        stats=small_sky_margin_args.catalog.partition_info.get_healpix_pixels(),
+        output_path=small_sky_margin_args.catalog_path,
+        storage_options=None,
+    )
+
+    output = file_io.append_paths_to_pointer(small_sky_margin_args.catalog_path, "Norder=0", "Dir=0")
+    assert file_io.does_file_or_directory_exist(output)

--- a/tests/hipscat_import/margin_cache/test_margin_cache_resume_plan.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_resume_plan.py
@@ -7,7 +7,6 @@ from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from hipscat_import.margin_cache.margin_cache_arguments import MarginCacheArguments
 from hipscat_import.margin_cache.margin_cache_resume_plan import (
     MarginCachePlan,
-    _create_margin_directory,
     _find_partition_margin_pixel_pairs,
 )
 
@@ -137,15 +136,3 @@ def test_partition_margin_pixel_pairs_negative(small_sky_margin_args):
     assert margin_pairs.iloc[-1]["partition_pixel"] == expected_pixel
     npt.assert_array_equal(margin_pairs.iloc[-10:]["margin_pixel"], expected)
     assert len(margin_pairs) == 536
-
-
-def test_create_margin_directory(small_sky_margin_args):
-    """Ensure create_margin_directory works on main partition_pixels"""
-    _create_margin_directory(
-        stats=small_sky_margin_args.catalog.partition_info.get_healpix_pixels(),
-        output_path=small_sky_margin_args.catalog_path,
-        storage_options=None,
-    )
-
-    output = file_io.append_paths_to_pointer(small_sky_margin_args.catalog_path, "Norder=0", "Dir=0")
-    assert file_io.does_file_or_directory_exist(output)


### PR DESCRIPTION
## Change Description

Closes #313 .

Adds a resume plan to margin cache generation.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

## Project-Specific Pull Request Checklists
<!--- Please only use the checklist that apply to your change type(s) -->

### New Feature Checklist
- [x] I have added or updated the docstrings associated with my feature using the [NumPy docstring format](https://numpydoc.readthedocs.io/en/latest/format.html)
- [ ] I have updated the tutorial to highlight my new feature (if appropriate)
- [x] I have added unit/End-to-End (E2E) test cases to cover my new feature
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)