### PR TITLE
Redact storage options, as this may include user keys.

### DIFF
--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -84,6 +84,9 @@ class InputReader(abc.ABC):
         Returns:
             dictionary with all argument_name -> argument_value as key -> value pairs.
         """
+        all_args = vars(self)
+        if "kwargs" in all_args and "storage_options" in all_args["kwargs"]:
+            all_args["kwargs"]["storage_options"] = "REDACTED"
         return {"input_reader_type": type(self).__name__, **vars(self)}
 
     def regular_file_exists(self, input_file, storage_options: Union[Dict[Any, Any], None] = None, **_kwargs):

--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -81,6 +81,10 @@ class InputReader(abc.ABC):
     def provenance_info(self) -> dict:
         """Create dictionary of parameters for provenance tracking.
 
+        If any `storage_options` have been provided as kwargs, we will replace the
+        value with ``REDACTED`` for the purpose of writing to provenance info, as it
+        may contain user names or API keys.
+
         Returns:
             dictionary with all argument_name -> argument_value as key -> value pairs.
         """

--- a/tests/hipscat_import/catalog/test_file_readers.py
+++ b/tests/hipscat_import/catalog/test_file_readers.py
@@ -220,11 +220,19 @@ def test_csv_reader_provenance_info(tmp_path, basic_catalog_info):
             "empty": "Int64",
             "numeric": int,
         },
+        storage_options={"user_name": "user_pii", "user_key": "SECRETS!"},
     )
     provenance_info = reader.provenance_info()
-    catalog_base_dir = os.path.join(tmp_path, "test_catalog")
+    catalog_base_dir = tmp_path / "test_catalog"
     os.makedirs(catalog_base_dir)
     io.write_provenance_info(catalog_base_dir, basic_catalog_info, provenance_info)
+
+    with open(catalog_base_dir / "provenance_info.json", "r", encoding="utf-8") as file:
+        data = file.read()
+        assert "test_catalog" in data
+        assert "REDACTED" in data
+        assert "user_pii" not in data
+        assert "SECRETS" not in data
 
 
 def test_parquet_reader(parquet_shards_shard_44_0):


### PR DESCRIPTION
## Change Description

The `storage_options` kwarg is very likely to contain sensitive user information, like API keys. Adds logic to suppress their storage in the `provenance_info.json` file.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation

### Bug Fix Checklist
- [x] My fix includes a new test that breaks as a result of the bug (if possible)
- [ ] My change includes a breaking change
  - [ ] My change includes backwards compatibility and deprecation warnings (if possible)