### PR TITLE
Tidy up some resume functionality

### DIFF
--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -26,10 +26,6 @@ class ResumePlan(PipelineResumePlan):
     """set of files (and job keys) that have yet to be split"""
     destination_pixel_map: Optional[List[Tuple[HealpixPixel, List[HealpixPixel], str]]] = None
     """Fully resolved map of destination pixels to constituent smaller pixels"""
-    delete_resume_log_files: bool = True
-    """should we delete task-level done files once each stage is complete?
-    if False, we will keep all sub-histograms from the mapping stage, and all
-    done marker files at the end of the pipeline."""
 
     MAPPING_STAGE = "mapping"
     SPLITTING_STAGE = "splitting"

--- a/src/hipscat_import/catalog/run_import.py
+++ b/src/hipscat_import/catalog/run_import.py
@@ -183,6 +183,5 @@ def run(args, client):
         step_progress.update(1)
         io.write_fits_map(args.catalog_path, raw_histogram, storage_options=args.output_storage_options)
         step_progress.update(1)
-        if args.resume_plan.delete_resume_log_files:
-            args.resume_plan.clean_resume_files()
+        args.resume_plan.clean_resume_files()
         step_progress.update(1)

--- a/src/hipscat_import/margin_cache/margin_cache.py
+++ b/src/hipscat_import/margin_cache/margin_cache.py
@@ -16,10 +16,7 @@ def generate_margin_cache(args, client):
         args (MarginCacheArguments): A valid `MarginCacheArguments` object.
         client (dask.distributed.Client): A dask distributed client object.
     """
-    partition_pixels = args.catalog.partition_info.get_healpix_pixels()
-    negative_pixels = args.catalog.generate_negative_tree_pixels()
-    combined_pixels = partition_pixels + negative_pixels
-    resume_plan = MarginCachePlan(args, combined_pixels=combined_pixels, partition_pixels=partition_pixels)
+    resume_plan = MarginCachePlan(args)
 
     if not resume_plan.is_mapping_done():
         futures = []
@@ -54,6 +51,7 @@ def generate_margin_cache(args, client):
                     partition_order=pix.order,
                     partition_pixel=pix.pixel,
                     original_catalog_metadata=paths.get_common_metadata_pointer(args.input_catalog_path),
+                    delete_intermediate_parquet_files=args.delete_intermediate_parquet_files,
                     input_storage_options=args.input_storage_options,
                 )
             )

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -24,6 +24,12 @@ class MarginCacheArguments(RuntimeArguments):
     order of healpix partitioning in the source catalog. if `margin_order` is left
     default or set to -1, then the `margin_order` will be set dynamically to the
     highest partition order plus 1."""
+    delete_intermediate_parquet_files: bool = True
+    """should we delete the smaller intermediate parquet files generated in the
+    splitting stage, once the relevant reducing stage is complete?"""
+    delete_resume_log_files: bool = True
+    """should we delete task-level done files once each stage is complete?
+    if False, we will keep all done marker files at the end of the pipeline."""
 
     input_catalog_path: str = ""
     """the path to the hipscat-formatted input catalog."""

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -25,6 +25,10 @@ class PipelineResumePlan:
     progress_bar: bool = True
     """if true, a tqdm progress bar will be displayed for user
     feedback of planning progress"""
+    delete_resume_log_files: bool = True
+    """should we delete task-level done files once each stage is complete?
+    if False, we will keep all sub-histograms from the mapping stage, and all
+    done marker files at the end of the pipeline."""
 
     ORIGINAL_INPUT_PATHS = "input_paths.txt"
 
@@ -109,7 +113,8 @@ class PipelineResumePlan:
 
     def clean_resume_files(self):
         """Remove all intermediate files created in execution."""
-        file_io.remove_directory(self.tmp_path, ignore_errors=True)
+        if self.delete_resume_log_files:
+            file_io.remove_directory(self.tmp_path, ignore_errors=True)
 
     def wait_for_futures(self, futures, stage_name, fail_fast=False):
         """Wait for collected futures to complete.

--- a/src/hipscat_import/soap/arguments.py
+++ b/src/hipscat_import/soap/arguments.py
@@ -28,9 +28,15 @@ class SoapArguments(RuntimeArguments):
     resume: bool = True
     """if there are existing intermediate resume files, should we
     read those and continue to run the pipeline where we left off"""
+    delete_resume_log_files: bool = True
+    """should we delete task-level done files once each stage is complete?
+    if False, we will keep all done marker files at the end of the pipeline."""
     write_leaf_files: bool = False
     """Should we also write out leaf parquet files (e.g. Norder/Dir/Npix.parquet)
     that represent the full association table"""
+    delete_intermediate_parquet_files: bool = True
+    """should we delete the smaller intermediate parquet files generated in the
+    mapping stage, once the relevant reducing stage is complete?"""
 
     compute_partition_size: int = 1_000_000_000
 

--- a/src/hipscat_import/soap/resume_plan.py
+++ b/src/hipscat_import/soap/resume_plan.py
@@ -36,7 +36,12 @@ class SoapPlan(PipelineResumePlan):
     def __init__(self, args: SoapArguments):
         if not args.tmp_path:  # pragma: no cover (not reachable, but required for mypy)
             raise ValueError("tmp_path is required")
-        super().__init__(resume=args.resume, progress_bar=args.progress_bar, tmp_path=args.tmp_path)
+        super().__init__(
+            resume=args.resume,
+            progress_bar=args.progress_bar,
+            tmp_path=args.tmp_path,
+            delete_resume_log_files=args.delete_resume_log_files,
+        )
         self.gather_plan(args)
 
     def gather_plan(self, args):

--- a/src/hipscat_import/soap/run_soap.py
+++ b/src/hipscat_import/soap/run_soap.py
@@ -43,6 +43,7 @@ def run(args, client):
                     soap_args=args,
                     object_pixel=object_pixel,
                     object_key=object_key,
+                    delete_input_files=args.delete_intermediate_parquet_files,
                 )
             )
 

--- a/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
@@ -144,6 +144,25 @@ def test_reduce_margin_shards(tmp_path):
         1,
         21,
         original_catalog_metadata=schema_path,
+        delete_intermediate_parquet_files=False,
+        input_storage_options=None,
+    )
+
+    result_path = paths.pixel_catalog_file(tmp_path, 1, 21)
+
+    validate_result_dataframe(result_path, 720)
+    assert os.path.exists(shard_dir)
+
+    # Run again with delete_intermediate_parquet_files. shard_dir doesn't exist at the end.
+    margin_cache_map_reduce.reduce_margin_shards(
+        intermediate_dir,
+        "1_21",
+        tmp_path,
+        None,
+        1,
+        21,
+        original_catalog_metadata=schema_path,
+        delete_intermediate_parquet_files=True,
         input_storage_options=None,
     )
 
@@ -177,6 +196,7 @@ def test_reduce_margin_shards_error(tmp_path, basic_data_shard_df, capsys):
             1,
             21,
             original_catalog_metadata=schema_path,
+            delete_intermediate_parquet_files=True,
             input_storage_options=None,
         )
 


### PR DESCRIPTION
## Change Description

A few clean-ups that don't change much functionality of resuming catalog, margin cache, or SOAP generation pipelines.

- Moves `delete_resume_log_files` up to the super class, so all resume plans can use the argument.
- Exposes user options for retaining intermediate files in margin generation and SOAP, as this was requested for catalog import and might be useful here as well.
- Moves margin cache pixel calculation more into the planning stages. Reduces the scope of the variables, and the negative pixel calculation can count toward the "planning" phase time.
- Only create directories for margin cache if the leaf files will be created.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation