### PR TITLE
Use the original catalog schema in more reads/writes.

### DIFF
--- a/src/hipscat_import/margin_cache/margin_cache.py
+++ b/src/hipscat_import/margin_cache/margin_cache.py
@@ -17,6 +17,7 @@ def generate_margin_cache(args, client):
         client (dask.distributed.Client): A dask distributed client object.
     """
     resume_plan = MarginCachePlan(args)
+    original_catalog_metadata = paths.get_common_metadata_pointer(args.input_catalog_path)
 
     if not resume_plan.is_mapping_done():
         futures = []
@@ -28,6 +29,7 @@ def generate_margin_cache(args, client):
                     partition_file=partition_file,
                     mapping_key=mapping_key,
                     input_storage_options=args.input_storage_options,
+                    original_catalog_metadata=original_catalog_metadata,
                     margin_pair_file=resume_plan.margin_pair_file,
                     margin_threshold=args.margin_threshold,
                     output_path=args.tmp_path,
@@ -50,7 +52,7 @@ def generate_margin_cache(args, client):
                     output_storage_options=args.output_storage_options,
                     partition_order=pix.order,
                     partition_pixel=pix.pixel,
-                    original_catalog_metadata=paths.get_common_metadata_pointer(args.input_catalog_path),
+                    original_catalog_metadata=original_catalog_metadata,
                     delete_intermediate_parquet_files=args.delete_intermediate_parquet_files,
                     input_storage_options=args.input_storage_options,
                 )

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -17,6 +17,7 @@ def map_pixel_shards(
     partition_file,
     mapping_key,
     input_storage_options,
+    original_catalog_metadata,
     margin_pair_file,
     margin_threshold,
     output_path,
@@ -26,7 +27,12 @@ def map_pixel_shards(
 ):
     """Creates margin cache shards from a source partition file."""
     try:
-        data = file_io.load_parquet_to_pandas(partition_file, storage_options=input_storage_options)
+        schema = file_io.read_parquet_metadata(
+            original_catalog_metadata, storage_options=input_storage_options
+        ).schema.to_arrow_schema()
+        data = file_io.load_parquet_to_pandas(
+            partition_file, schema=schema, storage_options=input_storage_options
+        )
 
         data["margin_pixel"] = hp.ang2pix(
             2**margin_order,
@@ -127,20 +133,19 @@ def reduce_margin_shards(
             intermediate_directory, HealpixPixel(partition_order, partition_pixel)
         )
         if file_io.does_file_or_directory_exist(shard_dir):
-            data = ds.dataset(shard_dir, format="parquet")
+            schema = file_io.read_parquet_metadata(
+                original_catalog_metadata, storage_options=input_storage_options
+            ).schema.to_arrow_schema()
+
+            schema = (
+                schema.append(pa.field("margin_Norder", pa.uint8()))
+                .append(pa.field("margin_Dir", pa.uint64()))
+                .append(pa.field("margin_Npix", pa.uint64()))
+            )
+            data = ds.dataset(shard_dir, format="parquet", schema=schema)
             full_df = data.to_table().to_pandas()
 
             if len(full_df):
-                schema = file_io.read_parquet_metadata(
-                    original_catalog_metadata, storage_options=input_storage_options
-                ).schema.to_arrow_schema()
-
-                schema = (
-                    schema.append(pa.field("margin_Norder", pa.uint8()))
-                    .append(pa.field("margin_Dir", pa.uint64()))
-                    .append(pa.field("margin_Npix", pa.uint64()))
-                )
-
                 margin_cache_dir = paths.pixel_directory(output_path, partition_order, partition_pixel)
                 file_io.make_directory(
                     margin_cache_dir, exist_ok=True, storage_options=output_storage_options

--- a/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
@@ -78,6 +78,7 @@ def test_map_pixel_shards_error(tmp_path, capsys):
             paths.pixel_catalog_file(tmp_path, 1, 0),
             mapping_key="1_21",
             input_storage_options=None,
+            original_catalog_metadata="",
             margin_pair_file="",
             margin_threshold=10,
             output_path=tmp_path,


### PR DESCRIPTION
## Change Description

With data re-generation on epyc, this closes #319.

## Solution Description

Forces the use of the original catalog schema for reading and writing the input catalog parquet files. This coerces data types in the same way we do for catalog import, and ensures that dtypes are consistent between the original and margin catalogs.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation