### PR TITLE
Update margin cache catalog info parameters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/astronomy-commons/hipscat.git@main

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -83,6 +83,9 @@ class MarginCacheArguments(RuntimeArguments):
             "catalog_name": self.output_artifact_name,
             "total_rows": total_rows,
             "catalog_type": "margin",
+            "epoch": self.catalog.catalog_info.epoch,
+            "ra_column": self.catalog.catalog_info.ra_column,
+            "dec_column": self.catalog.catalog_info.dec_column,
             "primary_catalog": self.input_catalog_path,
             "margin_threshold": self.margin_threshold,
         }

--- a/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_arguments_margin_cache.py
@@ -125,6 +125,9 @@ def test_to_catalog_info(small_sky_source_catalog, tmp_path):
     catalog_info = args.to_catalog_info(total_rows=10)
     assert catalog_info.catalog_name == args.output_artifact_name
     assert catalog_info.total_rows == 10
+    assert catalog_info.epoch == "J2000"
+    assert catalog_info.ra_column == "source_ra"
+    assert catalog_info.dec_column == "source_dec"
 
 
 def test_provenance_info(small_sky_source_catalog, tmp_path):


### PR DESCRIPTION
Adds the catalog specific metadata ("epoch", "ra" and "dec") to the margin catalog info output. Closes #331. 

- [X] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation