### PR TITLE
Enable "index file" reads for catalog import

### DIFF
--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -388,7 +388,7 @@ class IndexedParquetReader(InputReader):
     def read(self, input_file, read_columns=None):
         columns = read_columns or self.column_names
         file_names = self.read_index_file(input_file=input_file, **self.kwargs)
-        input_dataset = pyarrow.dataset.dataset(file_names)
+        (_, input_dataset) = file_io.read_parquet_dataset(file_names, **self.kwargs)
 
         batches, nrows = [], 0
         for batch in input_dataset.to_batches(

--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -4,6 +4,8 @@ import abc
 from typing import Any, Dict, Union
 
 import pandas as pd
+import pyarrow
+import pyarrow.dataset
 import pyarrow.parquet as pq
 from astropy.io import ascii as ascii_reader
 from astropy.table import Table
@@ -349,32 +351,61 @@ class ParquetReader(InputReader):
             yield smaller_table.to_pandas()
 
 
-class IndexedParquetReader(ParquetReader):
+class IndexedParquetReader(InputReader):
     """Reads an index file, containing paths to parquet files to be read and batched
 
-    See ParquetReader for additional configuration for reading parquet files.
+    Attributes:
+        chunksize (int): maximum number of rows to process at once.
+            Large files will be processed in chunks. Small files will be concatenated.
+            Also passed to pyarrow.dataset.Dataset.to_batches as `batch_size`.
+        batch_readahead (int): number of batches to read ahead.
+            Passed to pyarrow.dataset.Dataset.to_batches.
+        fragment_readahead (int): number of fragments to read ahead.
+            Passed to pyarrow.dataset.Dataset.to_batches.
+        use_threads (bool): whether to use multiple threads for reading.
+            Passed to pyarrow.dataset.Dataset.to_batches.
+        column_names (list[str] or None): Names of columns to use from the input dataset.
+            If None, use all columns.
+        kwargs: additional arguments to pass along to InputReader.read_index_file.
     """
 
+    def __init__(
+        self,
+        chunksize=500_000,
+        batch_readahead=16,
+        fragment_readahead=4,
+        use_threads=True,
+        column_names=None,
+        **kwargs,
+    ):
+        self.chunksize = chunksize
+        self.batch_readahead = batch_readahead
+        self.fragment_readahead = fragment_readahead
+        self.use_threads = use_threads
+        self.column_names = column_names
+        self.kwargs = kwargs
+
     def read(self, input_file, read_columns=None):
+        columns = read_columns or self.column_names
         file_names = self.read_index_file(input_file=input_file, **self.kwargs)
+        input_dataset = pyarrow.dataset.dataset(file_names)
 
-        batch_size = 0
-        batch_frames = []
-        for file in file_names:
-            for single_frame in super().read(file, read_columns=read_columns):
-                if batch_size + len(single_frame) >= self.chunksize:
-                    # We've hit our chunksize, send the batch off to the task.
-                    if len(batch_frames) == 0:
-                        yield single_frame
-                        batch_size = 0
-                    else:
-                        yield pd.concat(batch_frames, ignore_index=True)
-                        batch_frames = []
-                        batch_frames.append(single_frame)
-                        batch_size = len(single_frame)
-                else:
-                    batch_frames.append(single_frame)
-                    batch_size += len(single_frame)
+        batches, nrows = [], 0
+        for batch in input_dataset.to_batches(
+            batch_size=self.chunksize,
+            batch_readahead=self.batch_readahead,
+            fragment_readahead=self.fragment_readahead,
+            use_threads=self.use_threads,
+            columns=columns,
+        ):
+            if nrows + batch.num_rows > self.chunksize:
+                # We've hit the chunksize so load to a DataFrame and yield.
+                # There should always be at least one batch in here since batch_size == self.chunksize above.
+                yield pyarrow.Table.from_batches(batches).to_pandas()
+                batches, nrows = [], 0
 
-        if len(batch_frames) > 0:
-            yield pd.concat(batch_frames, ignore_index=True)
+            batches.append(batch)
+            nrows += batch.num_rows
+
+        if len(batches) > 0:
+            yield pyarrow.Table.from_batches(batches).to_pandas()

--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -3,6 +3,7 @@
 import abc
 from typing import Any, Dict, Union
 
+import pandas as pd
 import pyarrow.parquet as pq
 from astropy.io import ascii as ascii_reader
 from astropy.table import Table
@@ -30,8 +31,16 @@ def get_file_reader(
               includes `.csv.gz` and other compressed csv files
             - `fits`, flexible image transport system. often used for astropy tables.
             - `parquet`, compressed columnar data format
+            - `ecsv`, astropy's enhanced CSV
+            - `indexed_csv`, "index" style reader, that accepts a file with a list
+              of csv files that are appended in-memory
+            - `indexed_parquet`, "index" style reader, that accepts a file with a list
+              of parquet files that are appended in-memory
 
         chunksize (int): number of rows to read in a single iteration.
+            for single-file readers, large files are split into batches based on this value.
+            for index-style readers, we read files until we reach this chunksize and
+            create a single batch in-memory.
         schema_file (str): path to a parquet schema file. if provided, header names
             and column types will be pulled from the parquet schema metadata.
         column_names (list[str]): for CSV files, the names of columns if no header
@@ -59,7 +68,16 @@ def get_file_reader(
         )
     if file_format == "parquet":
         return ParquetReader(chunksize=chunksize, **kwargs)
-
+    if file_format == "indexed_csv":
+        return IndexedCsvReader(
+            chunksize=chunksize,
+            schema_file=schema_file,
+            column_names=column_names,
+            type_map=type_map,
+            **kwargs,
+        )
+    if file_format == "indexed_parquet":
+        return IndexedParquetReader(chunksize=chunksize, **kwargs)
     raise NotImplementedError(f"File Format: {file_format} not supported")
 
 
@@ -89,13 +107,27 @@ class InputReader(abc.ABC):
     def regular_file_exists(self, input_file, storage_options: Union[Dict[Any, Any], None] = None, **_kwargs):
         """Check that the `input_file` points to a single regular file
 
-        Raises
+        Raises:
             FileNotFoundError: if nothing exists at path, or directory found.
         """
         if not file_io.does_file_or_directory_exist(input_file, storage_options=storage_options):
             raise FileNotFoundError(f"File not found at path: {input_file}")
         if not file_io.is_regular_file(input_file, storage_options=storage_options):
             raise FileNotFoundError(f"Directory found at path - requires regular file: {input_file}")
+
+    def read_index_file(self, input_file, storage_options: Union[Dict[Any, Any], None] = None, **kwargs):
+        """Read an "indexed" file.
+
+        This should contain a list of paths to files to be read and batched.
+
+        Raises:
+            FileNotFoundError: if nothing exists at path, or directory found.
+        """
+        self.regular_file_exists(input_file, **kwargs)
+        file_names = file_io.load_text_file(input_file, storage_options=storage_options)
+        file_names = [f.strip() for f in file_names]
+        file_names = [f for f in file_names if f]
+        return file_names
 
 
 class CsvReader(InputReader):
@@ -171,6 +203,37 @@ class CsvReader(InputReader):
             **self.kwargs,
         ) as reader:
             yield from reader
+
+
+class IndexedCsvReader(CsvReader):
+    """Reads an index file, containing paths to CSV files to be read and batched
+
+    See CsvReader for additional configuration for reading CSV files.
+    """
+
+    def read(self, input_file, read_columns=None):
+        file_names = self.read_index_file(input_file=input_file, **self.kwargs)
+
+        batch_size = 0
+        batch_frames = []
+        for file in file_names:
+            for single_frame in super().read(file, read_columns=read_columns):
+                if batch_size + len(single_frame) >= self.chunksize:
+                    # We've hit our chunksize, send the batch off to the task.
+                    if len(batch_frames) == 0:
+                        yield single_frame
+                        batch_size = 0
+                    else:
+                        yield pd.concat(batch_frames, ignore_index=True)
+                        batch_frames = []
+                        batch_frames.append(single_frame)
+                        batch_size = len(single_frame)
+                else:
+                    batch_frames.append(single_frame)
+                    batch_size += len(single_frame)
+
+        if len(batch_frames) > 0:
+            yield pd.concat(batch_frames, ignore_index=True)
 
 
 class AstropyEcsvReader(InputReader):
@@ -284,3 +347,34 @@ class ParquetReader(InputReader):
             batch_size=self.chunksize, columns=columns, use_pandas_metadata=True
         ):
             yield smaller_table.to_pandas()
+
+
+class IndexedParquetReader(ParquetReader):
+    """Reads an index file, containing paths to parquet files to be read and batched
+
+    See ParquetReader for additional configuration for reading parquet files.
+    """
+
+    def read(self, input_file, read_columns=None):
+        file_names = self.read_index_file(input_file=input_file, **self.kwargs)
+
+        batch_size = 0
+        batch_frames = []
+        for file in file_names:
+            for single_frame in super().read(file, read_columns=read_columns):
+                if batch_size + len(single_frame) >= self.chunksize:
+                    # We've hit our chunksize, send the batch off to the task.
+                    if len(batch_frames) == 0:
+                        yield single_frame
+                        batch_size = 0
+                    else:
+                        yield pd.concat(batch_frames, ignore_index=True)
+                        batch_frames = []
+                        batch_frames.append(single_frame)
+                        batch_size = len(single_frame)
+                else:
+                    batch_frames.append(single_frame)
+                    batch_size += len(single_frame)
+
+        if len(batch_frames) > 0:
+            yield pd.concat(batch_frames, ignore_index=True)

--- a/tests/hipscat_import/catalog/test_run_round_trip.py
+++ b/tests/hipscat_import/catalog/test_run_round_trip.py
@@ -670,3 +670,50 @@ def test_gaia_ecsv(
     assert schema.equals(expected_parquet_schema, check_metadata=False)
     schema = pds.dataset(args.catalog_path, format="parquet").schema
     assert schema.equals(expected_parquet_schema, check_metadata=False)
+
+
+@pytest.mark.dask
+def test_import_indexed_csv(
+    dask_client,
+    indexed_files_dir,
+    tmp_path,
+):
+    """Use indexed-style CSV reads. There are two index files, and we expect
+    to have two batches worth of intermediate files."""
+    temp = tmp_path / "intermediate_files"
+    os.makedirs(temp)
+
+    args = ImportArguments(
+        output_artifact_name="indexed_csv",
+        input_file_list=[
+            indexed_files_dir / "csv_list_double_1_of_2.txt",
+            indexed_files_dir / "csv_list_double_2_of_2.txt",
+        ],
+        output_path=tmp_path,
+        file_reader="indexed_csv",
+        sort_columns="id",
+        tmp_dir=temp,
+        dask_tmp=temp,
+        highest_healpix_order=2,
+        delete_intermediate_parquet_files=False,
+        delete_resume_log_files=False,
+        pixel_threshold=3_000,
+        progress_bar=False,
+    )
+
+    runner.run(args, dask_client)
+
+    # Check that the catalog metadata file exists
+    catalog = Catalog.read_from_hipscat(args.catalog_path)
+    assert catalog.on_disk
+    assert catalog.catalog_path == args.catalog_path
+    assert len(catalog.get_healpix_pixels()) == 1
+
+    # Check that there are TWO intermediate parquet file (two index files).
+    assert_directory_contains(
+        temp / "indexed_csv" / "intermediate" / "order_0" / "dir_0" / "pixel_11",
+        [
+            "shard_split_0_0.parquet",
+            "shard_split_1_0.parquet",
+        ],
+    )

--- a/tests/hipscat_import/conftest.py
+++ b/tests/hipscat_import/conftest.py
@@ -2,6 +2,7 @@
 
 import os
 import re
+from pathlib import Path
 
 import healpy as hp
 import numpy as np
@@ -52,7 +53,7 @@ TEST_DIR = os.path.dirname(__file__)
 
 @pytest.fixture
 def test_data_dir():
-    return os.path.join(TEST_DIR, "data")
+    return Path(TEST_DIR) / "data"
 
 
 @pytest.fixture
@@ -118,6 +119,11 @@ def formats_fits(test_data_dir):
 @pytest.fixture
 def formats_pandasindex(test_data_dir):
     return os.path.join(test_data_dir, "test_formats", "pandasindex.parquet")
+
+
+@pytest.fixture
+def indexed_files_dir(test_data_dir):
+    return test_data_dir / "indexed_files"
 
 
 @pytest.fixture

--- a/tests/hipscat_import/data/indexed_files/csv_list_double_1_of_2.txt
+++ b/tests/hipscat_import/data/indexed_files/csv_list_double_1_of_2.txt
@@ -1,0 +1,3 @@
+tests/hipscat_import/data/small_sky_parts/catalog_00_of_05.csv
+tests/hipscat_import/data/small_sky_parts/catalog_01_of_05.csv
+

--- a/tests/hipscat_import/data/indexed_files/csv_list_double_2_of_2.txt
+++ b/tests/hipscat_import/data/indexed_files/csv_list_double_2_of_2.txt
@@ -1,0 +1,3 @@
+tests/hipscat_import/data/small_sky_parts/catalog_02_of_05.csv
+tests/hipscat_import/data/small_sky_parts/catalog_03_of_05.csv
+tests/hipscat_import/data/small_sky_parts/catalog_04_of_05.csv

--- a/tests/hipscat_import/data/indexed_files/csv_list_single.txt
+++ b/tests/hipscat_import/data/indexed_files/csv_list_single.txt
@@ -1,0 +1,6 @@
+tests/hipscat_import/data/small_sky_parts/catalog_00_of_05.csv
+tests/hipscat_import/data/small_sky_parts/catalog_01_of_05.csv
+tests/hipscat_import/data/small_sky_parts/catalog_02_of_05.csv
+tests/hipscat_import/data/small_sky_parts/catalog_03_of_05.csv
+tests/hipscat_import/data/small_sky_parts/catalog_04_of_05.csv
+

--- a/tests/hipscat_import/data/indexed_files/parquet_list_single.txt
+++ b/tests/hipscat_import/data/indexed_files/parquet_list_single.txt
@@ -1,0 +1,5 @@
+tests/hipscat_import/data/parquet_shards/order_0/dir_0/pixel_11/shard_0_0.parquet
+tests/hipscat_import/data/parquet_shards/order_0/dir_0/pixel_11/shard_1_0.parquet
+tests/hipscat_import/data/parquet_shards/order_0/dir_0/pixel_11/shard_2_0.parquet
+tests/hipscat_import/data/parquet_shards/order_0/dir_0/pixel_11/shard_3_0.parquet
+tests/hipscat_import/data/parquet_shards/order_0/dir_0/pixel_11/shard_4_0.parquet


### PR DESCRIPTION
## Change Description

Closes #308 .

## Solution Description

Creates a new kind of file reader for catalog import: indexed file reader. This uses a single "index" file as a task unit, and these files contain only paths to data files to be read. This enables batching many small input data files into larger chunks for the map and reduce stages of the pipeline. 

Implements an indexed reader for CSV and for Parquet files. In particular, the parquet reader utilizes pyarrow's parquet read `batch_readahead`, `fragment_readahead`, and multi-threading to further speed up reads of many small data files.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation