### PR TITLE
Only specify the astropy table columns once.

### DIFF
--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -306,7 +306,7 @@ class FitsReader(InputReader):
         table = Table.read(input_file, memmap=True, **self.kwargs)
         if read_columns:
             table.keep_columns(read_columns)
-        if self.column_names:
+        elif self.column_names:
             table.keep_columns(self.column_names)
         elif self.skip_column_names:
             table.remove_columns(self.skip_column_names)

--- a/tests/hipscat_import/catalog/test_file_readers.py
+++ b/tests/hipscat_import/catalog/test_file_readers.py
@@ -360,8 +360,16 @@ def test_read_fits_columns(formats_fits):
     frame = next(FitsReader(column_names=["id", "ra", "dec"]).read(formats_fits))
     assert list(frame.columns) == ["id", "ra", "dec"]
 
+    frame = next(FitsReader(column_names=["id", "ra", "dec"]).read(formats_fits, read_columns=["ra", "dec"]))
+    assert list(frame.columns) == ["ra", "dec"]
+
     frame = next(FitsReader(skip_column_names=["ra_error", "dec_error"]).read(formats_fits))
     assert list(frame.columns) == ["id", "ra", "dec", "test_id"]
+
+    frame = next(
+        FitsReader(skip_column_names=["ra_error", "dec_error"]).read(formats_fits, read_columns=["ra", "dec"])
+    )
+    assert list(frame.columns) == ["ra", "dec"]
 
 
 def test_fits_reader_provenance_info(tmp_path, basic_catalog_info):


### PR DESCRIPTION
## Change Description

Closes #335 .

When passing `read_columns` (as in the mapping stage), do not attempt to further limit the columns read from the fits file.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation