### PR TITLE
Require recent hipscat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dependencies = [
     "dask[complete]>=2024.3.0", # Includes dask expressions.
     "deprecated",
     "healpy",
-    "hipscat >=0.3.4",
+    "hipscat >=0.3.5",
     "ipykernel", # Support for Jupyter notebooks
     "numpy",
     "pandas",


### PR DESCRIPTION
## Change Description

Require latest version of hipscat, for margin catalog metadata.