### PR TITLE
Use list of names, instead of pandas index.

### DIFF
--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -192,7 +192,7 @@ class CsvReader(InputReader):
         if self.column_names:
             self.kwargs["names"] = self.column_names
         elif not self.header and schema_parquet is not None:
-            self.kwargs["names"] = schema_parquet.columns
+            self.kwargs["names"] = list(schema_parquet.columns)
 
         if self.type_map:
             self.kwargs["dtype"] = self.type_map


### PR DESCRIPTION
## Change Description

Closes #342 

## Solution Description

The kwarg for column names was being stored as the index of the pandas dataframe representing the parquet schema. This was unnecessary, as we only need the list of column names.