### PR TITLE
Use hipscat for healpix dependency.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ dynamic = ["version"]
 dependencies = [
     "dask[complete]>=2024.3.0", # Includes dask expressions.
     "deprecated",
-    "healpy",
     "hipscat >=0.3.5",
     "ipykernel", # Support for Jupyter notebooks
     "numpy",

--- a/src/hipscat_import/catalog/map_reduce.py
+++ b/src/hipscat_import/catalog/map_reduce.py
@@ -3,7 +3,7 @@
 import pickle
 from typing import Any, Dict, Union
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq

--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -6,7 +6,7 @@ import pickle
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 from hipscat import pixel_math
 from hipscat.io import FilePointer, file_io

--- a/src/hipscat_import/catalog/sparse_histogram.py
+++ b/src/hipscat_import/catalog/sparse_histogram.py
@@ -1,6 +1,6 @@
 """Sparse 1-D histogram of healpix pixel counts."""
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 from scipy.sparse import csc_array, load_npz, save_npz, sparray
 

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -2,7 +2,7 @@ import warnings
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Union
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 from hipscat.catalog import Catalog
 from hipscat.catalog.margin_cache.margin_cache_catalog_info import MarginCacheCatalogInfo
 from hipscat.io.validation import is_valid_catalog

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -1,4 +1,4 @@
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 import pandas as pd
 import pyarrow as pa

--- a/src/hipscat_import/soap/resume_plan.py
+++ b/src/hipscat_import/soap/resume_plan.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 from hipscat.catalog import Catalog
 from hipscat.io import file_io

--- a/tests/hipscat_import/catalog/test_map_reduce.py
+++ b/tests/hipscat_import/catalog/test_map_reduce.py
@@ -4,7 +4,7 @@ import os
 import pickle
 from io import StringIO
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import hipscat.pixel_math as hist
 import numpy as np
 import numpy.testing as npt

--- a/tests/hipscat_import/catalog/test_map_reduce.py
+++ b/tests/hipscat_import/catalog/test_map_reduce.py
@@ -4,8 +4,8 @@ import os
 import pickle
 from io import StringIO
 
-import hipscat.pixel_math.healpix_shim as hp
 import hipscat.pixel_math as hist
+import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 import numpy.testing as npt
 import pandas as pd

--- a/tests/hipscat_import/conftest.py
+++ b/tests/hipscat_import/conftest.py
@@ -4,7 +4,7 @@ import os
 import re
 from pathlib import Path
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 import numpy.testing as npt
 import pandas as pd

--- a/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
@@ -1,6 +1,6 @@
 import os
 
-import healpy as hp
+import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 import pandas as pd
 import pytest


### PR DESCRIPTION
## Change Description

See https://github.com/astronomy-commons/hipscat/issues/53 and https://github.com/astronomy-commons/hipscat/pull/297

Uses the healpix shim methods for any healpy calls.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
