### PR TITLE
Read parquet files with arrow schema

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/astronomy-commons/hipscat.git@add-arrow-schema-to-catalog
+git+https://github.com/astronomy-commons/hipscat.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/astronomy-commons/hipscat.git@main
+git+https://github.com/astronomy-commons/hipscat.git@add-arrow-schema-to-catalog

--- a/src/hipscat_import/index/map_reduce.py
+++ b/src/hipscat_import/index/map_reduce.py
@@ -7,7 +7,9 @@ from hipscat.io import paths
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 
 
-def read_leaf_file(input_file, include_columns, include_hipscat_index, drop_duplicates, storage_options):
+def read_leaf_file(
+    input_file, include_columns, include_hipscat_index, drop_duplicates, schema, storage_options
+):
     """Mapping function called once per input file.
 
     Reads the leaf parquet file, and returns with appropriate columns and duplicates dropped."""
@@ -15,6 +17,7 @@ def read_leaf_file(input_file, include_columns, include_hipscat_index, drop_dupl
         input_file,
         columns=include_columns,
         engine="pyarrow",
+        schema=schema,
         storage_options=storage_options,
     )
 
@@ -51,6 +54,7 @@ def create_index(args, client):
         include_columns=include_columns,
         include_hipscat_index=args.include_hipscat_index,
         drop_duplicates=args.drop_duplicates,
+        schema=args.input_catalog.schema,
         storage_options=args.input_storage_options,
     )
 

--- a/src/hipscat_import/soap/arguments.py
+++ b/src/hipscat_import/soap/arguments.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any, Dict, Union
 
+from hipscat.catalog import Catalog
 from hipscat.catalog.association_catalog.association_catalog import AssociationCatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.io.validation import is_valid_catalog
@@ -52,12 +53,20 @@ class SoapArguments(RuntimeArguments):
         if not is_valid_catalog(self.object_catalog_dir, storage_options=self.object_storage_options):
             raise ValueError("object_catalog_dir not a valid catalog")
 
+        self.object_catalog = Catalog.read_from_hipscat(
+            catalog_path=self.object_catalog_dir, storage_options=self.object_storage_options
+        )
+
         if not self.source_catalog_dir:
             raise ValueError("source_catalog_dir is required")
         if not self.source_object_id_column:
             raise ValueError("source_object_id_column is required")
         if not is_valid_catalog(self.source_catalog_dir, storage_options=self.source_storage_options):
             raise ValueError("source_catalog_dir not a valid catalog")
+
+        self.source_catalog = Catalog.read_from_hipscat(
+            catalog_path=self.source_catalog_dir, storage_options=self.source_storage_options
+        )
 
         if self.compute_partition_size < 100_000:
             raise ValueError("compute_partition_size must be at least 100_000")

--- a/src/hipscat_import/soap/map_reduce.py
+++ b/src/hipscat_import/soap/map_reduce.py
@@ -107,7 +107,7 @@ def count_joins(soap_args: SoapArguments, source_pixel: HealpixPixel, object_pix
             read_columns = [soap_args.source_object_id_column, soap_args.source_id_column]
         else:
             read_columns = [soap_args.source_object_id_column]
-        source_data = file_io.load_parquet_to_pandas(
+        source_data = file_io.read_parquet_file_to_pandas(
             source_path, columns=read_columns, storage_options=soap_args.source_storage_options
         ).set_index(soap_args.source_object_id_column)
 

--- a/src/hipscat_import/soap/map_reduce.py
+++ b/src/hipscat_import/soap/map_reduce.py
@@ -24,7 +24,10 @@ def _count_joins_for_object(source_data, source_pixel, object_pixel, soap_args):
         pixel_number=object_pixel.pixel,
     )
     object_data = file_io.load_parquet_to_pandas(
-        object_path, columns=[soap_args.object_id_column], storage_options=soap_args.object_storage_options
+        object_path,
+        columns=[soap_args.object_id_column],
+        schema=soap_args.object_catalog.schema,
+        storage_options=soap_args.object_storage_options,
     ).set_index(soap_args.object_id_column)
 
     joined_data = source_data.merge(object_data, how="inner", left_index=True, right_index=True)
@@ -105,7 +108,10 @@ def count_joins(soap_args: SoapArguments, source_pixel: HealpixPixel, object_pix
         else:
             read_columns = [soap_args.source_object_id_column]
         source_data = file_io.load_parquet_to_pandas(
-            source_path, columns=read_columns, storage_options=soap_args.source_storage_options
+            source_path,
+            columns=read_columns,
+            schema=soap_args.source_catalog.schema,
+            storage_options=soap_args.source_storage_options,
         ).set_index(soap_args.source_object_id_column)
 
         remaining_sources = len(source_data)


### PR DESCRIPTION
Provide the arrow schema to reading of parquet files in index and soap pipelines.

- [ ] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation