### PR TITLE
Use consistent pandas file io method.

### DIFF
--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -184,7 +184,7 @@ class CsvReader(InputReader):
         if self.schema_file:
             if self.parquet_kwargs is None:
                 self.parquet_kwargs = {}
-            schema_parquet = file_io.load_parquet_to_pandas(
+            schema_parquet = file_io.read_parquet_file_to_pandas(
                 FilePointer(self.schema_file),
                 **self.parquet_kwargs,
             )

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -30,7 +30,7 @@ def map_pixel_shards(
         schema = file_io.read_parquet_metadata(
             original_catalog_metadata, storage_options=input_storage_options
         ).schema.to_arrow_schema()
-        data = file_io.load_parquet_to_pandas(
+        data = file_io.read_parquet_file_to_pandas(
             partition_file, schema=schema, storage_options=input_storage_options
         )
 

--- a/src/hipscat_import/soap/map_reduce.py
+++ b/src/hipscat_import/soap/map_reduce.py
@@ -23,7 +23,7 @@ def _count_joins_for_object(source_data, source_pixel, object_pixel, soap_args):
         pixel_order=object_pixel.order,
         pixel_number=object_pixel.pixel,
     )
-    object_data = file_io.load_parquet_to_pandas(
+    object_data = file_io.read_parquet_file_to_pandas(
         object_path, columns=[soap_args.object_id_column], storage_options=soap_args.object_storage_options
     ).set_index(soap_args.object_id_column)
 
@@ -104,7 +104,7 @@ def count_joins(soap_args: SoapArguments, source_pixel: HealpixPixel, object_pix
             read_columns = [soap_args.source_object_id_column, soap_args.source_id_column]
         else:
             read_columns = [soap_args.source_object_id_column]
-        source_data = file_io.load_parquet_to_pandas(
+        source_data = file_io.read_parquet_file_to_pandas(
             source_path, columns=read_columns, storage_options=soap_args.source_storage_options
         ).set_index(soap_args.source_object_id_column)
 


### PR DESCRIPTION
## Change Description

Related to [hipscat ](https://github.com/astronomy-commons/hipscat/issues/309)

Removes uses of `load_parquet_to_pandas` in favor of `read_parquet_file_to_pandas`

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation