### PR TITLE
Fix CSV reader from recent changes in hipscat library

### DIFF
--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -205,13 +205,12 @@ class CsvReader(InputReader):
         if read_columns:
             self.kwargs["usecols"] = read_columns
 
-        with file_io.load_csv_to_pandas(
+        return file_io.load_csv_to_pandas_generator(
             FilePointer(input_file),
             chunksize=self.chunksize,
             header=self.header,
             **self.kwargs,
-        ) as reader:
-            yield from reader
+        )
 
 
 class IndexedCsvReader(CsvReader):


### PR DESCRIPTION
## Change Description

Use appropriate scope for pandas chunk reading generator, with file-ownership in hipscat method.