### PR TITLE
Add schema to source data in SOAP pipeline

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,3 +9,4 @@ sphinx
 sphinx-autoapi
 sphinx-copybutton
 sphinx-book-theme
+git+https://github.com/astronomy-commons/hipscat.git@main

--- a/src/hipscat_import/soap/map_reduce.py
+++ b/src/hipscat_import/soap/map_reduce.py
@@ -108,7 +108,10 @@ def count_joins(soap_args: SoapArguments, source_pixel: HealpixPixel, object_pix
         else:
             read_columns = [soap_args.source_object_id_column]
         source_data = file_io.read_parquet_file_to_pandas(
-            source_path, columns=read_columns, storage_options=soap_args.source_storage_options
+            source_path,
+            columns=read_columns,
+            schema=soap_args.source_catalog.schema,
+            storage_options=soap_args.source_storage_options,
         ).set_index(soap_args.source_object_id_column)
 
         remaining_sources = len(source_data)


### PR DESCRIPTION
Adds the arrow schema as an argument to the parquet reading of the source data files in the SOAP pipeline, which I missed in https://github.com/astronomy-commons/hipscat-import/pull/348. It also fixes the documentation build, which is failing, by installing `hipscat` from source.

- [ ] My PR includes a link to the issue that I am addressing

## Code Quality
- [X] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation