### PR TITLE
Distinguish error message for empty list vs None.

### DIFF
--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -116,8 +116,6 @@ class ImportArguments(RuntimeArguments):
         if self.catalog_type not in ("source", "object"):
             raise ValueError("catalog_type should be one of `source` or `object`")
 
-        if (not self.input_path and not self.input_file_list) or (self.input_path and self.input_file_list):
-            raise ValueError("exactly one of input_path or input_file_list is required")
         if self.file_reader is None:
             raise ValueError("file_reader is required")
         if isinstance(self.file_reader, str):

--- a/src/hipscat_import/runtime_arguments.py
+++ b/src/hipscat_import/runtime_arguments.py
@@ -151,13 +151,21 @@ def find_input_paths(
     """
     input_paths = []
     if input_path:
+        if input_file_list:
+            raise ValueError("exactly one of input_path or input_file_list is required")
+
         if not file_io.does_file_or_directory_exist(input_path, storage_options=storage_options):
             raise FileNotFoundError("input_path not found on local storage")
         input_paths = file_io.find_files_matching_path(
             input_path, file_matcher, include_protocol=True, storage_options=storage_options
         )
-    elif input_file_list:
+    elif not input_file_list is None:
+        # It's common for users to accidentally pass in an empty list. Give them a friendly error.
+        if len(input_file_list) == 0:
+            raise ValueError("input_file_list is empty")
         input_paths = input_file_list
+    else:
+        raise ValueError("exactly one of input_path or input_file_list is required")
     if len(input_paths) == 0:
         raise FileNotFoundError("No input files found")
     return input_paths

--- a/tests/hipscat_import/catalog/test_argument_validation.py
+++ b/tests/hipscat_import/catalog/test_argument_validation.py
@@ -71,6 +71,17 @@ def test_invalid_paths(blank_data_dir, tmp_path):
             output_path=tmp_path,
         )
 
+    # Too many paths!
+    with pytest.raises(ValueError, match="exactly one of"):
+        ImportArguments(
+            output_artifact_name="catalog",
+            input_path=blank_data_dir,
+            input_file_list=[blank_data_dir],
+            file_reader="csv",
+            output_path=tmp_path,
+            progress_bar=False,
+        )
+
 
 def test_missing_paths(tmp_path):
     ## Input path has no files

--- a/tests/hipscat_import/catalog/test_argument_validation.py
+++ b/tests/hipscat_import/catalog/test_argument_validation.py
@@ -34,6 +34,22 @@ def test_empty_required(small_sky_parts_dir, tmp_path):
             output_path=tmp_path,
         )
 
+    with pytest.raises(ValueError, match="input_file_list is required"):
+        ImportArguments(
+            output_artifact_name="catalog",
+            file_reader="csv",
+            input_file_list=None,
+            output_path=tmp_path,
+        )
+
+    with pytest.raises(ValueError, match="input_file_list is empty"):
+        ImportArguments(
+            output_artifact_name="catalog",
+            file_reader="csv",
+            input_file_list=[],
+            output_path=tmp_path,
+        )
+
 
 def test_invalid_paths(blank_data_dir, tmp_path):
     """Required arguments are provided, but paths aren't found."""


### PR DESCRIPTION
## Change Description

Closes #341.

It's pretty common for users to use the result of a glob operation as input in the `input_file_list` argument. If the glob expression is mal-formed and the results are empty, they'll get a confusing error. This distinguishes the behavior from not passing in anything to hopefully give a more helpful message.

## Code Quality
- [x] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation