### PR TITLE
Bundle dependency requirements with release

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -16,8 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  deploy:
-
+  test-and-deploy:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
@@ -29,8 +28,19 @@ jobs:
         python-version: '3.10'
     - name: Install dependencies
       run: |
+        sudo apt-get update
         python -m pip install --upgrade pip
-        pip install build
+        pip install .
+    - name: Create lock requirements file
+      run: pip list --format=freeze --exclude "hipscat-import" > requirements.txt
+    - name: Install dev dependencies
+      run: pip install .[dev]
+    - name: Run unit tests with pytest
+      run: python -m pytest tests
+    - name: Run dask-on-ray tests with pytest
+      run: python -m pytest tests --use_ray
+    - name: Install build tools
+      run: pip install build
     - name: Build package
       run: python -m build
     - name: Publish package

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt


### PR DESCRIPTION
This pull request updates the `publish-to-pypi.yml` workflow, which runs on each package release, to include a file with the list of installed requirements at the time of publishing. Also, according to the following https://github.com/astronomy-commons/hipscat-import/issues/362#issuecomment-2278864308, I added an extra verification step to the pipeline, running the unit tests prior to packaging. Closes #362.

- [X] My PR includes a link to the issue that I am addressing

### Usage details

The requirements file helps recreate environments with consistent transitive dependencies, and make deployments on Dask Kubernetes clusters reproducible. When installing `hipscat-import` on a Docker image one should:

```bash
$ pip download hipscat-import --no-deps --no-binary :all: # download the sdist
$ tar -xzf hipscat-import* # unzip it
$ cd hipscat-import*/
$ pip install -r requirements.txt # install the locked dependencies
```

## Code Quality
- [X] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation