### PR TITLE
Update LINCC logo with 2024 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/astronomy-commons/lsdb.io/blob/main/assets/img/lincc-logo.png?raw=true" width="300" height="100">
+<img src="https://github.com/astronomy-commons/lsdb/blob/main/docs/lincc-logo.png?raw=true" width="300" height="100">
 
 # hipscat-import
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://github.com/lincc-frameworks/tape/blob/main/docs/DARK_Combo_sm.png?raw=true" width="300" height="100">
+<img src="https://github.com/astronomy-commons/lsdb.io/blob/main/assets/img/lincc-logo.png?raw=true" width="300" height="100">
 
 # hipscat-import
 


### PR DESCRIPTION
Update LINCC logo with 2024 version as requested in https://github.com/astronomy-commons/lsdb/issues/403