### PR TITLE
Replace FilePointer with universal pathlib

### DIFF
--- a/docs/catalogs/arguments.rst
+++ b/docs/catalogs/arguments.rst
@@ -169,7 +169,7 @@ You can find the full API documentation for
     )
 
 If you're reading from cloud storage, or otherwise have some filesystem credential
-dict, put those in ``input_storage_options``.
+dict, initialize ``input_file`` using ``universal_pathlib``'s utilities.
 
 Indexed batching strategy
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -304,7 +304,7 @@ preferable to delete any existing contents, however, as this may cause
 unexpected side effects.
 
 If you're writing to cloud storage, or otherwise have some filesystem credential
-dict, put those in ``output_storage_options``.
+dict, initialize ``output_path`` using ``universal_pathlib``'s utilities.
 
 In addition, you can specify directories to use for various intermediate files:
 

--- a/docs/guide/index_table.rst
+++ b/docs/guide/index_table.rst
@@ -229,7 +229,7 @@ preferable to delete any existing contents, however, as this may cause
 unexpected side effects.
 
 If you're writing to cloud storage, or otherwise have some filesystem credential
-dict, put those in ``output_storage_options``.
+dict, initialize ``output_path`` using ``universal_pathlib``'s utilities.
 
 In addition, you can specify directories to use for various intermediate files:
 

--- a/docs/guide/margin_cache.rst
+++ b/docs/guide/margin_cache.rst
@@ -141,7 +141,7 @@ preferable to delete any existing contents, however, as this may cause
 unexpected side effects.
 
 If you're writing to cloud storage, or otherwise have some filesystem credential
-dict, put those in ``output_storage_options``.
+dict, initialize ``output_path`` using ``universal_pathlib``'s utilities.
 
 In addition, you can specify directories to use for various intermediate files:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pyyaml",
     "scipy",
     "tqdm",
+    "universal_pathlib",
 ]
 
 # On a mac, install optional dependencies with `pip install '.[dev]'` (include the single quotes)

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 from hipscat.catalog.catalog import CatalogInfo
 from hipscat.pixel_math import hipscat_id
@@ -25,7 +25,7 @@ class ImportArguments(RuntimeArguments):
 
     catalog_type: str = "object"
     """level of catalog data, object (things in the sky) or source (detections)"""
-    input_path: Optional[str | Path | UPath] = None
+    input_path: str | Path | UPath | None = None
     """path to search for the input data"""
     input_file_list: List[str | Path | UPath] = field(default_factory=list)
     """can be used instead of input_path to import only specified files"""
@@ -44,7 +44,7 @@ class ImportArguments(RuntimeArguments):
     resolve the counter within the same higher-order pixel space"""
     add_hipscat_index: bool = True
     """add the hipscat spatial index field alongside the data"""
-    use_schema_file: Optional[str | Path | UPath] = None
+    use_schema_file: str | Path | UPath | None = None
     """path to a parquet file with schema metadata. this will be used for column
     metadata when writing the files, if specified"""
     expected_total_rows: int = 0

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List, Optional
 
 from hipscat.catalog.catalog import CatalogInfo
@@ -24,11 +25,11 @@ class ImportArguments(RuntimeArguments):
 
     catalog_type: str = "object"
     """level of catalog data, object (things in the sky) or source (detections)"""
-    input_path: Optional[UPath] = None
+    input_path: Optional[str | Path | UPath] = None
     """path to search for the input data"""
-    input_file_list: List[str] = field(default_factory=list)
+    input_file_list: List[str | Path | UPath] = field(default_factory=list)
     """can be used instead of input_path to import only specified files"""
-    input_paths: List[UPath] = field(default_factory=list)
+    input_paths: List[str | Path | UPath] = field(default_factory=list)
     """resolved list of all files that will be used in the importer"""
 
     ra_column: str = "ra"
@@ -43,7 +44,7 @@ class ImportArguments(RuntimeArguments):
     resolve the counter within the same higher-order pixel space"""
     add_hipscat_index: bool = True
     """add the hipscat spatial index field alongside the data"""
-    use_schema_file: str | None = None
+    use_schema_file: Optional[str | Path | UPath] = None
     """path to a parquet file with schema metadata. this will be used for column
     metadata when writing the files, if specified"""
     expected_total_rows: int = 0

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Union
+from typing import List, Optional
 
 from hipscat.catalog.catalog import CatalogInfo
 from hipscat.pixel_math import hipscat_id
@@ -24,14 +24,12 @@ class ImportArguments(RuntimeArguments):
 
     catalog_type: str = "object"
     """level of catalog data, object (things in the sky) or source (detections)"""
-    input_path: UPath | None = None
+    input_path: Optional[UPath] = None
     """path to search for the input data"""
     input_file_list: List[str] = field(default_factory=list)
     """can be used instead of input_path to import only specified files"""
     input_paths: List[UPath] = field(default_factory=list)
     """resolved list of all files that will be used in the importer"""
-    input_storage_options: Union[Dict[Any, Any], None] = None
-    """optional dictionary of abstract filesystem credentials for the INPUT."""
 
     ra_column: str = "ra"
     """column for right ascension"""
@@ -130,12 +128,7 @@ class ImportArguments(RuntimeArguments):
                 raise ValueError("When using _hipscat_index for position, no sort columns should be added")
 
         # Basic checks complete - make more checks and create directories where necessary
-        self.input_paths = find_input_paths(
-            self.input_path,
-            "**/*.*",
-            self.input_file_list,
-            storage_options=self.input_storage_options,
-        )
+        self.input_paths = find_input_paths(self.input_path, "**/*.*", self.input_file_list)
 
     def to_catalog_info(self, total_rows) -> CatalogInfo:
         """Catalog-type-specific dataset info."""

--- a/src/hipscat_import/catalog/arguments.py
+++ b/src/hipscat_import/catalog/arguments.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Union
 
 from hipscat.catalog.catalog import CatalogInfo
-from hipscat.io import FilePointer
 from hipscat.pixel_math import hipscat_id
+from upath import UPath
 
 from hipscat_import.catalog.file_readers import InputReader, get_file_reader
 from hipscat_import.runtime_arguments import RuntimeArguments, find_input_paths
@@ -24,11 +24,11 @@ class ImportArguments(RuntimeArguments):
 
     catalog_type: str = "object"
     """level of catalog data, object (things in the sky) or source (detections)"""
-    input_path: FilePointer | None = None
+    input_path: UPath | None = None
     """path to search for the input data"""
-    input_file_list: List[FilePointer] = field(default_factory=list)
+    input_file_list: List[str] = field(default_factory=list)
     """can be used instead of input_path to import only specified files"""
-    input_paths: List[FilePointer] = field(default_factory=list)
+    input_paths: List[UPath] = field(default_factory=list)
     """resolved list of all files that will be used in the importer"""
     input_storage_options: Union[Dict[Any, Any], None] = None
     """optional dictionary of abstract filesystem credentials for the INPUT."""

--- a/src/hipscat_import/catalog/file_readers.py
+++ b/src/hipscat_import/catalog/file_readers.py
@@ -1,7 +1,6 @@
 """File reading generators for common file types."""
 
 import abc
-from typing import Any, Dict, Union
 
 import pandas as pd
 import pyarrow
@@ -114,15 +113,15 @@ class InputReader(abc.ABC):
             all_args["kwargs"]["storage_options"] = "REDACTED"
         return {"input_reader_type": type(self).__name__, **vars(self)}
 
-    def regular_file_exists(self, input_file, storage_options: Union[Dict[Any, Any], None] = None, **_kwargs):
+    def regular_file_exists(self, input_file, **_kwargs):
         """Check that the `input_file` points to a single regular file
 
         Raises:
             FileNotFoundError: if nothing exists at path, or directory found.
         """
-        if not file_io.does_file_or_directory_exist(input_file, storage_options=storage_options):
+        if not file_io.does_file_or_directory_exist(input_file):
             raise FileNotFoundError(f"File not found at path: {input_file}")
-        if not file_io.is_regular_file(input_file, storage_options=storage_options):
+        if not file_io.is_regular_file(input_file):
             raise FileNotFoundError(f"Directory found at path - requires regular file: {input_file}")
 
     def read_index_file(self, input_file, upath_kwargs=None, **kwargs):

--- a/src/hipscat_import/catalog/map_reduce.py
+++ b/src/hipscat_import/catalog/map_reduce.py
@@ -177,9 +177,9 @@ def split_pixels(
                     pixel_dir, f"shard_{splitting_key}_{chunk_number}.parquet"
                 )
                 if _has_named_index(filtered_data):
-                    filtered_data.to_parquet(output_file, index=True)
+                    filtered_data.to_parquet(output_file.path, index=True, filesystem=output_file.fs)
                 else:
-                    filtered_data.to_parquet(output_file, index=False)
+                    filtered_data.to_parquet(output_file.path, index=False, filesystem=output_file.fs)
                 del filtered_data, data_indexes
 
         ResumePlan.splitting_key_done(tmp_path=resume_path, splitting_key=splitting_key)
@@ -305,9 +305,9 @@ def reduce_pixel_shards(
 
         if schema:
             schema = _modify_arrow_schema(schema, add_hipscat_index)
-            dataframe.to_parquet(destination_file, schema=schema)
+            dataframe.to_parquet(destination_file.path, schema=schema, filesystem=destination_file.fs)
         else:
-            dataframe.to_parquet(destination_file)
+            dataframe.to_parquet(destination_file.path, filesystem=destination_file.fs)
 
         del dataframe, merged_table, tables
 

--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -9,8 +9,9 @@ from typing import List, Optional, Tuple
 import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 from hipscat import pixel_math
-from hipscat.io import FilePointer, file_io
+from hipscat.io import file_io
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
+from upath import UPath
 
 from hipscat_import.catalog.sparse_histogram import SparseHistogram
 from hipscat_import.pipeline_resume_plan import PipelineResumePlan
@@ -20,7 +21,7 @@ from hipscat_import.pipeline_resume_plan import PipelineResumePlan
 class ResumePlan(PipelineResumePlan):
     """Container class for holding the state of each file in the pipeline plan."""
 
-    input_paths: List[FilePointer] = field(default_factory=list)
+    input_paths: List[UPath] = field(default_factory=list)
     """resolved list of all files that will be used in the importer"""
     map_files: List[Tuple[str, str]] = field(default_factory=list)
     """list of files (and job keys) that have yet to be mapped"""
@@ -49,7 +50,7 @@ class ResumePlan(PipelineResumePlan):
         simple_progress_bar: bool = False,
         input_paths=None,
         tmp_path=None,
-        tmp_base_path: FilePointer | None = None,
+        tmp_base_path: UPath | None = None,
         delete_resume_log_files: bool = True,
         delete_intermediate_parquet_files: bool = True,
         output_storage_options: dict | None = None,

--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -53,7 +53,6 @@ class ResumePlan(PipelineResumePlan):
         tmp_base_path: UPath | None = None,
         delete_resume_log_files: bool = True,
         delete_intermediate_parquet_files: bool = True,
-        output_storage_options: dict | None = None,
         run_stages: List[str] | None = None,
         import_args=None,
     ):
@@ -66,7 +65,6 @@ class ResumePlan(PipelineResumePlan):
                 tmp_base_path=import_args.tmp_base_path,
                 delete_resume_log_files=import_args.delete_resume_log_files,
                 delete_intermediate_parquet_files=import_args.delete_intermediate_parquet_files,
-                output_storage_options=import_args.output_storage_options,
             )
             if import_args.debug_stats_only:
                 run_stages = ["mapping", "finishing"]
@@ -80,7 +78,6 @@ class ResumePlan(PipelineResumePlan):
                 tmp_base_path=tmp_base_path,
                 delete_resume_log_files=delete_resume_log_files,
                 delete_intermediate_parquet_files=delete_intermediate_parquet_files,
-                output_storage_options=output_storage_options,
             )
             self.input_paths = input_paths
         self.gather_plan(run_stages)
@@ -263,7 +260,7 @@ class ResumePlan(PipelineResumePlan):
         pixel_threshold,
         drop_empty_siblings,
         expected_total_rows,
-    ) -> str:
+    ) -> UPath:
         """Get a pointer to the existing alignment file for the pipeline, or
         generate a new alignment using provided arguments.
 

--- a/src/hipscat_import/catalog/resume_plan.py
+++ b/src/hipscat_import/catalog/resume_plan.py
@@ -6,14 +6,14 @@ import pickle
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
-import hipscat.pixel_math as hist
 import hipscat.pixel_math.healpix_shim as hp
 import numpy as np
 from hipscat import pixel_math
 from hipscat.io import file_io
+from hipscat.pixel_math import empty_histogram
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
-from upath import UPath
 from numpy import frombuffer
+from upath import UPath
 
 from hipscat_import.catalog.sparse_histogram import SparseHistogram
 from hipscat_import.pipeline_resume_plan import PipelineResumePlan
@@ -175,7 +175,7 @@ class ResumePlan(PipelineResumePlan):
             if len(remaining_map_files) > 0:
                 raise RuntimeError(f"{len(remaining_map_files)} map stages did not complete successfully.")
             histogram_files = file_io.find_files_matching_path(self.tmp_path, self.HISTOGRAMS_DIR, "*.npz")
-            aggregate_histogram = hist.empty_histogram(healpix_order)
+            aggregate_histogram = empty_histogram(healpix_order)
             for partial_file_name in histogram_files:
                 partial = SparseHistogram.from_file(partial_file_name)
                 partial_as_array = partial.to_array()

--- a/src/hipscat_import/catalog/run_import.py
+++ b/src/hipscat_import/catalog/run_import.py
@@ -114,7 +114,6 @@ def run(args, client):
                     use_schema_file=args.use_schema_file,
                     use_hipscat_index=args.use_hipscat_index,
                     delete_input_files=args.delete_intermediate_parquet_files,
-                    storage_options=args.output_storage_options,
                 )
             )
 
@@ -128,34 +127,25 @@ def run(args, client):
                 catalog_base_dir=args.catalog_path,
                 dataset_info=catalog_info,
                 tool_args=args.provenance_info(),
-                storage_options=args.output_storage_options,
             )
             step_progress.update(1)
 
-            io.write_catalog_info(
-                catalog_base_dir=args.catalog_path,
-                dataset_info=catalog_info,
-                storage_options=args.output_storage_options,
-            )
+            io.write_catalog_info(catalog_base_dir=args.catalog_path, dataset_info=catalog_info)
             step_progress.update(1)
             partition_info = PartitionInfo.from_healpix(resume_plan.get_destination_pixels())
             partition_info_file = paths.get_partition_info_pointer(args.catalog_path)
-            partition_info.write_to_file(partition_info_file, storage_options=args.output_storage_options)
+            partition_info.write_to_file(partition_info_file)
             if not args.debug_stats_only:
-                parquet_rows = write_parquet_metadata(
-                    args.catalog_path, storage_options=args.output_storage_options
-                )
+                parquet_rows = write_parquet_metadata(args.catalog_path)
                 if total_rows > 0 and parquet_rows != total_rows:
                     raise ValueError(
                         f"Number of rows in parquet ({parquet_rows}) "
                         f"does not match expectation ({total_rows})"
                     )
             else:
-                partition_info.write_to_metadata_files(
-                    args.catalog_path, storage_options=args.output_storage_options
-                )
+                partition_info.write_to_metadata_files(args.catalog_path)
             step_progress.update(1)
-            io.write_fits_map(args.catalog_path, raw_histogram, storage_options=args.output_storage_options)
+            io.write_fits_map(args.catalog_path, raw_histogram)
             step_progress.update(1)
             resume_plan.clean_resume_files()
             step_progress.update(1)

--- a/src/hipscat_import/index/arguments.py
+++ b/src/hipscat_import/index/arguments.py
@@ -19,7 +19,7 @@ class IndexArguments(RuntimeArguments):
     """Data class for holding indexing arguments"""
 
     ## Input
-    input_catalog_path: Optional[str | Path | UPath] = None
+    input_catalog_path: str | Path | UPath | None = None
     input_catalog: Optional[Catalog] = None
     indexing_column: str = ""
     extra_columns: List[str] = field(default_factory=list)

--- a/src/hipscat_import/index/arguments.py
+++ b/src/hipscat_import/index/arguments.py
@@ -1,6 +1,9 @@
 """Utility to hold all arguments required throughout indexing"""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List, Optional
 
 from hipscat.catalog import Catalog
@@ -16,7 +19,7 @@ class IndexArguments(RuntimeArguments):
     """Data class for holding indexing arguments"""
 
     ## Input
-    input_catalog_path: Optional[UPath] = None
+    input_catalog_path: Optional[str | Path | UPath] = None
     input_catalog: Optional[Catalog] = None
     indexing_column: str = ""
     extra_columns: List[str] = field(default_factory=list)

--- a/src/hipscat_import/index/arguments.py
+++ b/src/hipscat_import/index/arguments.py
@@ -1,11 +1,12 @@
 """Utility to hold all arguments required throughout indexing"""
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import List, Optional
 
 from hipscat.catalog import Catalog
 from hipscat.catalog.index.index_catalog_info import IndexCatalogInfo
 from hipscat.io.validation import is_valid_catalog
+from upath import UPath
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -15,10 +16,8 @@ class IndexArguments(RuntimeArguments):
     """Data class for holding indexing arguments"""
 
     ## Input
-    input_catalog_path: str = ""
+    input_catalog_path: Optional[UPath] = None
     input_catalog: Optional[Catalog] = None
-    input_storage_options: Union[Dict[Any, Any], None] = None
-    """optional dictionary of abstract filesystem credentials for the INPUT."""
     indexing_column: str = ""
     extra_columns: List[str] = field(default_factory=list)
 
@@ -58,11 +57,9 @@ class IndexArguments(RuntimeArguments):
         if not self.include_hipscat_index and not self.include_order_pixel:
             raise ValueError("At least one of include_hipscat_index or include_order_pixel must be True")
 
-        if not is_valid_catalog(self.input_catalog_path, storage_options=self.input_storage_options):
+        if not is_valid_catalog(self.input_catalog_path):
             raise ValueError("input_catalog_path not a valid catalog")
-        self.input_catalog = Catalog.read_from_hipscat(
-            catalog_path=self.input_catalog_path, storage_options=self.input_storage_options
-        )
+        self.input_catalog = Catalog.read_from_hipscat(catalog_path=self.input_catalog_path)
         if self.include_radec:
             catalog_info = self.input_catalog.catalog_info
             self.extra_columns.extend([catalog_info.ra_column, catalog_info.dec_column])

--- a/src/hipscat_import/index/map_reduce.py
+++ b/src/hipscat_import/index/map_reduce.py
@@ -2,14 +2,11 @@
 
 import dask.dataframe as dd
 import numpy as np
-import pandas as pd
 from hipscat.io import file_io, paths
 from hipscat.pixel_math.hipscat_id import HIPSCAT_ID_COLUMN
 
 
-def read_leaf_file(
-    input_file, include_columns, include_hipscat_index, drop_duplicates, schema, storage_options
-):
+def read_leaf_file(input_file, include_columns, include_hipscat_index, drop_duplicates, schema):
     """Mapping function called once per input file.
 
     Reads the leaf parquet file, and returns with appropriate columns and duplicates dropped."""
@@ -18,7 +15,6 @@ def read_leaf_file(
         columns=include_columns,
         engine="pyarrow",
         schema=schema,
-        # storage_options=storage_options,
     )
 
     data = data.reset_index()
@@ -51,7 +47,6 @@ def create_index(args, client):
         include_hipscat_index=args.include_hipscat_index,
         drop_duplicates=args.drop_duplicates,
         schema=args.input_catalog.schema,
-        storage_options=args.input_storage_options,
     )
 
     if args.include_order_pixel:

--- a/src/hipscat_import/index/run_index.py
+++ b/src/hipscat_import/index/run_index.py
@@ -27,20 +27,11 @@ def run(args, client):
             catalog_base_dir=args.catalog_path,
             dataset_info=index_catalog_info,
             tool_args=args.provenance_info(),
-            storage_options=args.output_storage_options,
         )
         step_progress.update(1)
-        write_metadata.write_catalog_info(
-            catalog_base_dir=args.catalog_path,
-            dataset_info=index_catalog_info,
-            storage_options=args.output_storage_options,
-        )
+        write_metadata.write_catalog_info(catalog_base_dir=args.catalog_path, dataset_info=index_catalog_info)
         step_progress.update(1)
-        file_io.remove_directory(
-            args.tmp_path, ignore_errors=True, storage_options=args.output_storage_options
-        )
+        file_io.remove_directory(args.tmp_path, ignore_errors=True)
         step_progress.update(1)
-        parquet_metadata.write_parquet_metadata(
-            args.catalog_path, order_by_healpix=False, storage_options=args.output_storage_options
-        )
+        parquet_metadata.write_parquet_metadata(args.catalog_path, order_by_healpix=False)
         step_progress.update(1)

--- a/src/hipscat_import/margin_cache/margin_cache.py
+++ b/src/hipscat_import/margin_cache/margin_cache.py
@@ -21,7 +21,7 @@ def generate_margin_cache(args, client):
     if not resume_plan.is_mapping_done():
         futures = []
         for mapping_key, pix in resume_plan.get_remaining_map_keys():
-            partition_file = paths.pixel_catalog_file(args.input_catalog_path, pix.order, pix.pixel)
+            partition_file = paths.pixel_catalog_file(args.input_catalog_path, pix)
             futures.append(
                 client.submit(
                     mcmr.map_pixel_shards,

--- a/src/hipscat_import/margin_cache/margin_cache.py
+++ b/src/hipscat_import/margin_cache/margin_cache.py
@@ -27,7 +27,6 @@ def generate_margin_cache(args, client):
                     mcmr.map_pixel_shards,
                     partition_file=partition_file,
                     mapping_key=mapping_key,
-                    input_storage_options=args.input_storage_options,
                     original_catalog_metadata=original_catalog_metadata,
                     margin_pair_file=resume_plan.margin_pair_file,
                     margin_threshold=args.margin_threshold,
@@ -49,27 +48,21 @@ def generate_margin_cache(args, client):
                     intermediate_directory=args.tmp_path,
                     reducing_key=reducing_key,
                     output_path=args.catalog_path,
-                    output_storage_options=args.output_storage_options,
                     partition_order=pix.order,
                     partition_pixel=pix.pixel,
                     original_catalog_metadata=original_catalog_metadata,
                     delete_intermediate_parquet_files=args.delete_intermediate_parquet_files,
-                    input_storage_options=args.input_storage_options,
                 )
             )
         resume_plan.wait_for_reducing(futures)
 
     with resume_plan.print_progress(total=4, stage_name="Finishing") as step_progress:
-        total_rows = parquet_metadata.write_parquet_metadata(
-            args.catalog_path, storage_options=args.output_storage_options
-        )
+        total_rows = parquet_metadata.write_parquet_metadata(args.catalog_path)
         step_progress.update(1)
         metadata_path = paths.get_parquet_metadata_pointer(args.catalog_path)
-        partition_info = PartitionInfo.read_from_file(
-            metadata_path, storage_options=args.output_storage_options
-        )
+        partition_info = PartitionInfo.read_from_file(metadata_path)
         partition_info_file = paths.get_partition_info_pointer(args.catalog_path)
-        partition_info.write_to_file(partition_info_file, storage_options=args.output_storage_options)
+        partition_info.write_to_file(partition_info_file)
 
         step_progress.update(1)
         margin_catalog_info = args.to_catalog_info(int(total_rows))
@@ -77,15 +70,10 @@ def generate_margin_cache(args, client):
             catalog_base_dir=args.catalog_path,
             dataset_info=margin_catalog_info,
             tool_args=args.provenance_info(),
-            storage_options=args.output_storage_options,
         )
         write_metadata.write_catalog_info(
-            catalog_base_dir=args.catalog_path,
-            dataset_info=margin_catalog_info,
-            storage_options=args.output_storage_options,
+            catalog_base_dir=args.catalog_path, dataset_info=margin_catalog_info
         )
         step_progress.update(1)
-        file_io.remove_directory(
-            args.tmp_path, ignore_errors=True, storage_options=args.output_storage_options
-        )
+        file_io.remove_directory(args.tmp_path, ignore_errors=True)
         step_progress.update(1)

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
 import hipscat.pixel_math.healpix_shim as hp
 from hipscat.catalog import Catalog
@@ -38,7 +38,7 @@ class MarginCacheArguments(RuntimeArguments):
     """should we delete task-level done files once each stage is complete?
     if False, we will keep all done marker files at the end of the pipeline."""
 
-    input_catalog_path: Optional[str | Path | UPath] = None
+    input_catalog_path: str | Path | UPath | None = None
     """the path to the hipscat-formatted input catalog."""
     debug_filter_pixel_list: List[HealpixPixel] = field(default_factory=list)
     """debug setting. if provided, we will first filter the catalog to the pixels

--- a/src/hipscat_import/margin_cache/margin_cache_arguments.py
+++ b/src/hipscat_import/margin_cache/margin_cache_arguments.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List, Optional
 
 import hipscat.pixel_math.healpix_shim as hp
@@ -35,7 +38,7 @@ class MarginCacheArguments(RuntimeArguments):
     """should we delete task-level done files once each stage is complete?
     if False, we will keep all done marker files at the end of the pipeline."""
 
-    input_catalog_path: Optional[UPath] = None
+    input_catalog_path: Optional[str | Path | UPath] = None
     """the path to the hipscat-formatted input catalog."""
     debug_filter_pixel_list: List[HealpixPixel] = field(default_factory=list)
     """debug setting. if provided, we will first filter the catalog to the pixels

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -165,7 +165,9 @@ def reduce_margin_shards(
 
                 margin_cache_file_path = paths.pixel_catalog_file(output_path, healpix_pixel)
 
-                full_df.to_parquet(margin_cache_file_path.path, schema=schema, filesystem=margin_cache_file_path.fs)
+                full_df.to_parquet(
+                    margin_cache_file_path.path, schema=schema, filesystem=margin_cache_file_path.fs
+                )
                 if delete_intermediate_parquet_files:
                     file_io.remove_directory(shard_dir)
 

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -132,7 +132,7 @@ def _to_pixel_shard(
         )
         margin_data = margin_data.sort_index()
 
-        margin_data.to_parquet(shard_path)
+        margin_data.to_parquet(shard_path.path, filesystem=shard_path.fs)
 
 
 def reduce_margin_shards(
@@ -165,7 +165,7 @@ def reduce_margin_shards(
 
                 margin_cache_file_path = paths.pixel_catalog_file(output_path, healpix_pixel)
 
-                full_df.to_parquet(margin_cache_file_path, schema=schema)
+                full_df.to_parquet(margin_cache_file_path.path, schema=schema, filesystem=margin_cache_file_path.fs)
                 if delete_intermediate_parquet_files:
                     file_io.remove_directory(shard_dir)
 

--- a/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hipscat_import/margin_cache/margin_cache_map_reduce.py
@@ -114,7 +114,7 @@ def _to_pixel_shard(
 
         file_io.make_directory(shard_dir, exist_ok=True)
 
-        shard_path = paths.pixel_catalog_file(partition_dir, source_pixel.order, source_pixel.pixel)
+        shard_path = paths.pixel_catalog_file(partition_dir, source_pixel)
 
         rename_columns = {
             PartitionInfo.METADATA_ORDER_COLUMN_NAME: f"margin_{PartitionInfo.METADATA_ORDER_COLUMN_NAME}",
@@ -153,9 +153,8 @@ def reduce_margin_shards(
 ):
     """Reduce all partition pixel directories into a single file"""
     try:
-        shard_dir = get_pixel_cache_directory(
-            intermediate_directory, HealpixPixel(partition_order, partition_pixel)
-        )
+        healpix_pixel = HealpixPixel(partition_order, partition_pixel)
+        shard_dir = get_pixel_cache_directory(intermediate_directory, healpix_pixel)
         if file_io.does_file_or_directory_exist(shard_dir):
             schema = file_io.read_parquet_metadata(
                 original_catalog_metadata, storage_options=input_storage_options
@@ -175,9 +174,7 @@ def reduce_margin_shards(
                     margin_cache_dir, exist_ok=True, storage_options=output_storage_options
                 )
 
-                margin_cache_file_path = paths.pixel_catalog_file(
-                    output_path, partition_order, partition_pixel
-                )
+                margin_cache_file_path = paths.pixel_catalog_file(output_path, healpix_pixel)
 
                 full_df.to_parquet(
                     margin_cache_file_path, schema=schema, storage_options=output_storage_options

--- a/src/hipscat_import/margin_cache/margin_cache_resume_plan.py
+++ b/src/hipscat_import/margin_cache/margin_cache_resume_plan.py
@@ -37,7 +37,6 @@ class MarginCachePlan(PipelineResumePlan):
             tmp_base_path=args.tmp_base_path,
             delete_resume_log_files=args.delete_resume_log_files,
             delete_intermediate_parquet_files=args.delete_intermediate_parquet_files,
-            output_storage_options=args.output_storage_options,
         )
         self._gather_plan(args)
 

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -23,8 +23,6 @@ class PipelineResumePlan:
     """path for any intermediate files"""
     tmp_base_path: UPath | None = None
     """temporary base directory: either `tmp_dir` or `dask_dir`, if those were provided by the user"""
-    output_storage_options: dict | None = None
-    """optional dictionary of abstract filesystem credentials for the output."""
     resume: bool = True
     """if there are existing intermediate resume files, should we
     read those and continue to run pipeline where we left off"""
@@ -53,12 +51,10 @@ class PipelineResumePlan:
         """
         if file_io.directory_has_contents(self.tmp_path):
             if not self.resume:
-                file_io.remove_directory(
-                    self.tmp_path, ignore_errors=True, storage_options=self.output_storage_options
-                )
+                file_io.remove_directory(self.tmp_path, ignore_errors=True)
             else:
                 print(f"tmp_path ({self.tmp_path}) contains intermediate files; resuming prior progress.")
-        file_io.make_directory(self.tmp_path, exist_ok=True, storage_options=self.output_storage_options)
+        file_io.make_directory(self.tmp_path, exist_ok=True)
 
     def done_file_exists(self, stage_name):
         """Is there a file at a given path?
@@ -132,7 +128,7 @@ class PipelineResumePlan:
             # Use the temporary directory base path if the user provided it, or
             # delete the intermediate directory from inside the output directory
             path = self.tmp_base_path if self.tmp_base_path is not None else self.tmp_path
-            file_io.remove_directory(path, ignore_errors=True, storage_options=self.output_storage_options)
+            file_io.remove_directory(path, ignore_errors=True)
 
     def wait_for_futures(self, futures, stage_name, fail_fast=False):
         """Wait for collected futures to complete.

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 from dask.distributed import as_completed, get_worker
 from dask.distributed import print as dask_print
@@ -22,7 +21,7 @@ class PipelineResumePlan:
 
     tmp_path: UPath
     """path for any intermediate files"""
-    tmp_base_path: Optional[str | Path | UPath] = None
+    tmp_base_path: str | Path | UPath | None = None
     """temporary base directory: either `tmp_dir` or `dask_dir`, if those were provided by the user"""
     resume: bool = True
     """if there are existing intermediate resume files, should we

--- a/src/hipscat_import/pipeline_resume_plan.py
+++ b/src/hipscat_import/pipeline_resume_plan.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Optional
 
 from dask.distributed import as_completed, get_worker
 from dask.distributed import print as dask_print
@@ -21,7 +22,7 @@ class PipelineResumePlan:
 
     tmp_path: UPath
     """path for any intermediate files"""
-    tmp_base_path: UPath | None = None
+    tmp_base_path: Optional[str | Path | UPath] = None
     """temporary base directory: either `tmp_dir` or `dask_dir`, if those were provided by the user"""
     resume: bool = True
     """if there are existing intermediate resume files, should we

--- a/src/hipscat_import/runtime_arguments.py
+++ b/src/hipscat_import/runtime_arguments.py
@@ -6,7 +6,6 @@ import re
 from dataclasses import dataclass
 from importlib.metadata import version
 from pathlib import Path
-from typing import Optional
 
 from hipscat.io import file_io
 from upath import UPath
@@ -19,13 +18,13 @@ class RuntimeArguments:
     """Data class for holding runtime arguments"""
 
     ## Output
-    output_path: Optional[str | Path | UPath] = None
+    output_path: str | Path | UPath | None = None
     """base path where new catalog should be output"""
     output_artifact_name: str = ""
     """short, convenient name for the catalog"""
 
     ## Execution
-    tmp_dir: Optional[str | Path | UPath] = None
+    tmp_dir: str | Path | UPath | None = None
     """path for storing intermediate files"""
     resume: bool = True
     """If True, we try to read any existing intermediate files and continue to run
@@ -38,14 +37,14 @@ class RuntimeArguments:
     """if displaying a progress bar, use a text-only simple progress
     bar instead of widget. this can be useful in some environments when running
     in a notebook where ipywidgets cannot be used (see `progress_bar` argument)"""
-    dask_tmp: Optional[str | Path | UPath] = None
+    dask_tmp: str | Path | UPath | None = None
     """directory for dask worker space. this should be local to
     the execution of the pipeline, for speed of reads and writes"""
     dask_n_workers: int = 1
     """number of workers for the dask client"""
     dask_threads_per_worker: int = 1
     """number of threads per dask worker"""
-    resume_tmp: Optional[str | Path | UPath] = None
+    resume_tmp: str | Path | UPath | None = None
     """directory for intermediate resume files, when needed. see RTD for more info."""
 
     completion_email_address: str = ""

--- a/src/hipscat_import/runtime_arguments.py
+++ b/src/hipscat_import/runtime_arguments.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from importlib.metadata import version
+from pathlib import Path
+from typing import Optional
 
 from hipscat.io import file_io
 from upath import UPath
@@ -17,13 +19,13 @@ class RuntimeArguments:
     """Data class for holding runtime arguments"""
 
     ## Output
-    output_path: str = ""
+    output_path: Optional[str | Path | UPath] = None
     """base path where new catalog should be output"""
     output_artifact_name: str = ""
     """short, convenient name for the catalog"""
 
     ## Execution
-    tmp_dir: str = ""
+    tmp_dir: Optional[str | Path | UPath] = None
     """path for storing intermediate files"""
     resume: bool = True
     """If True, we try to read any existing intermediate files and continue to run
@@ -36,14 +38,14 @@ class RuntimeArguments:
     """if displaying a progress bar, use a text-only simple progress
     bar instead of widget. this can be useful in some environments when running
     in a notebook where ipywidgets cannot be used (see `progress_bar` argument)"""
-    dask_tmp: str = ""
+    dask_tmp: Optional[str | Path | UPath] = None
     """directory for dask worker space. this should be local to
     the execution of the pipeline, for speed of reads and writes"""
     dask_n_workers: int = 1
     """number of workers for the dask client"""
     dask_threads_per_worker: int = 1
     """number of threads per dask worker"""
-    resume_tmp: str = ""
+    resume_tmp: Optional[str | Path | UPath] = None
     """directory for intermediate resume files, when needed. see RTD for more info."""
 
     completion_email_address: str = ""

--- a/src/hipscat_import/soap/arguments.py
+++ b/src/hipscat_import/soap/arguments.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
 
 from hipscat.catalog import Catalog
 from hipscat.catalog.association_catalog.association_catalog import AssociationCatalogInfo
@@ -18,11 +17,11 @@ class SoapArguments(RuntimeArguments):
     """Data class for holding source-object association arguments"""
 
     ## Input - Object catalog
-    object_catalog_dir: Optional[str | Path | UPath] = None
+    object_catalog_dir: str | Path | UPath | None = None
     object_id_column: str = ""
 
     ## Input - Source catalog
-    source_catalog_dir: Optional[str | Path | UPath] = None
+    source_catalog_dir: str | Path | UPath | None = None
     source_object_id_column: str = ""
     source_id_column: str = ""
 

--- a/src/hipscat_import/soap/arguments.py
+++ b/src/hipscat_import/soap/arguments.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 
 from hipscat.catalog import Catalog
@@ -15,11 +18,11 @@ class SoapArguments(RuntimeArguments):
     """Data class for holding source-object association arguments"""
 
     ## Input - Object catalog
-    object_catalog_dir: Optional[UPath] = None
+    object_catalog_dir: Optional[str | Path | UPath] = None
     object_id_column: str = ""
 
     ## Input - Source catalog
-    source_catalog_dir: Optional[UPath] = None
+    source_catalog_dir: Optional[str | Path | UPath] = None
     source_object_id_column: str = ""
     source_id_column: str = ""
 

--- a/src/hipscat_import/soap/arguments.py
+++ b/src/hipscat_import/soap/arguments.py
@@ -1,10 +1,11 @@
 from dataclasses import dataclass
-from typing import Any, Dict, Union
+from typing import Optional
 
 from hipscat.catalog import Catalog
 from hipscat.catalog.association_catalog.association_catalog import AssociationCatalogInfo
 from hipscat.catalog.catalog_type import CatalogType
 from hipscat.io.validation import is_valid_catalog
+from upath import UPath
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -14,17 +15,13 @@ class SoapArguments(RuntimeArguments):
     """Data class for holding source-object association arguments"""
 
     ## Input - Object catalog
-    object_catalog_dir: str = ""
+    object_catalog_dir: Optional[UPath] = None
     object_id_column: str = ""
-    object_storage_options: Union[Dict[Any, Any], None] = None
-    """optional dictionary of abstract filesystem credentials for the OBJECT catalog."""
 
     ## Input - Source catalog
-    source_catalog_dir: str = ""
+    source_catalog_dir: Optional[UPath] = None
     source_object_id_column: str = ""
     source_id_column: str = ""
-    source_storage_options: Union[Dict[Any, Any], None] = None
-    """optional dictionary of abstract filesystem credentials for the SOURCE catalog."""
 
     resume: bool = True
     """if there are existing intermediate resume files, should we
@@ -50,23 +47,19 @@ class SoapArguments(RuntimeArguments):
             raise ValueError("object_catalog_dir is required")
         if not self.object_id_column:
             raise ValueError("object_id_column is required")
-        if not is_valid_catalog(self.object_catalog_dir, storage_options=self.object_storage_options):
+        if not is_valid_catalog(self.object_catalog_dir):
             raise ValueError("object_catalog_dir not a valid catalog")
 
-        self.object_catalog = Catalog.read_from_hipscat(
-            catalog_path=self.object_catalog_dir, storage_options=self.object_storage_options
-        )
+        self.object_catalog = Catalog.read_from_hipscat(catalog_path=self.object_catalog_dir)
 
         if not self.source_catalog_dir:
             raise ValueError("source_catalog_dir is required")
         if not self.source_object_id_column:
             raise ValueError("source_object_id_column is required")
-        if not is_valid_catalog(self.source_catalog_dir, storage_options=self.source_storage_options):
+        if not is_valid_catalog(self.source_catalog_dir):
             raise ValueError("source_catalog_dir not a valid catalog")
 
-        self.source_catalog = Catalog.read_from_hipscat(
-            catalog_path=self.source_catalog_dir, storage_options=self.source_storage_options
-        )
+        self.source_catalog = Catalog.read_from_hipscat(catalog_path=self.source_catalog_dir)
 
         if self.compute_partition_size < 100_000:
             raise ValueError("compute_partition_size must be at least 100_000")

--- a/src/hipscat_import/soap/map_reduce.py
+++ b/src/hipscat_import/soap/map_reduce.py
@@ -6,11 +6,11 @@ import numpy as np
 import pandas as pd
 import pyarrow.parquet as pq
 from hipscat.catalog.association_catalog.partition_join_info import PartitionJoinInfo
-from hipscat.io import FilePointer, file_io, paths
-from hipscat.io.file_io.file_pointer import get_fs, strip_leading_slash_for_pyarrow
+from hipscat.io import file_io, paths
 from hipscat.io.parquet_metadata import get_healpix_pixel_from_metadata
 from hipscat.pixel_math.healpix_pixel import HealpixPixel
 from hipscat.pixel_math.healpix_pixel_function import get_pixel_argsort
+from upath import UPath
 
 from hipscat_import.pipeline_resume_plan import get_pixel_cache_directory, print_task_failure
 from hipscat_import.soap.arguments import SoapArguments
@@ -18,11 +18,7 @@ from hipscat_import.soap.resume_plan import SoapPlan
 
 
 def _count_joins_for_object(source_data, source_pixel, object_pixel, soap_args):
-    object_path = paths.pixel_catalog_file(
-        catalog_base_dir=soap_args.object_catalog_dir,
-        pixel_order=object_pixel.order,
-        pixel_number=object_pixel.pixel,
-    )
+    object_path = paths.pixel_catalog_file(soap_args.object_catalog_dir, object_pixel)
     object_data = file_io.read_parquet_file_to_pandas(
         object_path,
         columns=[soap_args.object_id_column],
@@ -80,9 +76,7 @@ def _write_count_results(cache_path, source_healpix, results):
 
     file_io.write_dataframe_to_csv(
         dataframe=dataframe,
-        file_pointer=file_io.append_paths_to_pointer(
-            cache_path, f"{source_healpix.order}_{source_healpix.pixel}.csv"
-        ),
+        file_pointer=cache_path / f"{source_healpix.order}_{source_healpix.pixel}.csv",
         index=False,
     )
 
@@ -98,11 +92,7 @@ def count_joins(soap_args: SoapArguments, source_pixel: HealpixPixel, object_pix
             of the object catalog to be joined.
     """
     try:
-        source_path = paths.pixel_catalog_file(
-            catalog_base_dir=file_io.get_file_pointer_from_path(soap_args.source_catalog_dir),
-            pixel_order=source_pixel.order,
-            pixel_number=source_pixel.pixel,
-        )
+        source_path = paths.pixel_catalog_file(soap_args.source_catalog_dir, source_pixel)
         if soap_args.write_leaf_files and soap_args.source_object_id_column != soap_args.source_id_column:
             read_columns = [soap_args.source_object_id_column, soap_args.source_id_column]
         else:
@@ -165,7 +155,7 @@ def combine_partial_results(input_path, output_path, output_storage_options) -> 
 
     file_io.write_dataframe_to_csv(
         dataframe=matched,
-        file_pointer=file_io.append_paths_to_pointer(output_path, "partition_join_info.csv"),
+        file_pointer=output_path / "partition_join_info.csv",
         index=False,
         storage_options=output_storage_options,
     )
@@ -173,7 +163,7 @@ def combine_partial_results(input_path, output_path, output_storage_options) -> 
     if len(unmatched) > 0:
         file_io.write_dataframe_to_csv(
             dataframe=unmatched,
-            file_pointer=file_io.append_paths_to_pointer(output_path, "unmatched_sources.csv"),
+            file_pointer=output_path / "unmatched_sources.csv",
             index=False,
             storage_options=output_storage_options,
         )
@@ -181,7 +171,7 @@ def combine_partial_results(input_path, output_path, output_storage_options) -> 
     primary_only = matched.groupby(["Norder", "Dir", "Npix"])["num_rows"].sum().reset_index()
     file_io.write_dataframe_to_csv(
         dataframe=primary_only,
-        file_pointer=file_io.append_paths_to_pointer(output_path, "partition_info.csv"),
+        file_pointer=output_path / "partition_info.csv",
         index=False,
         storage_options=output_storage_options,
     )
@@ -226,18 +216,15 @@ def reduce_joins(
             shards.append(pq.read_table(shard_file_name))
 
         # Write all of the shards into a single parquet file, one row-group-per-shard.
-        starting_catalog_path = FilePointer(str(soap_args.catalog_path))
-        destination_dir = paths.pixel_directory(starting_catalog_path, object_pixel.order, object_pixel.pixel)
+        destination_dir = paths.pixel_directory(
+            soap_args.catalog_path, object_pixel.order, object_pixel.pixel
+        )
         file_io.make_directory(
             destination_dir, exist_ok=True, storage_options=soap_args.output_storage_options
         )
 
-        output_file = paths.pixel_catalog_file(starting_catalog_path, object_pixel.order, object_pixel.pixel)
-        file_system, output_file = get_fs(
-            file_pointer=output_file, storage_options=soap_args.output_storage_options
-        )
-        output_file = strip_leading_slash_for_pyarrow(output_file, protocol=file_system.protocol)
-        with pq.ParquetWriter(output_file, shards[0].schema, filesystem=file_system) as writer:
+        output_file = paths.pixel_catalog_file(soap_args.catalog_path, object_pixel)
+        with pq.ParquetWriter(output_file.path, shards[0].schema, filesystem=output_file.fs) as writer:
             for table in shards:
                 writer.write_table(table)
 

--- a/src/hipscat_import/soap/resume_plan.py
+++ b/src/hipscat_import/soap/resume_plan.py
@@ -43,7 +43,6 @@ class SoapPlan(PipelineResumePlan):
             tmp_base_path=args.tmp_base_path,
             delete_resume_log_files=args.delete_resume_log_files,
             delete_intermediate_parquet_files=args.delete_intermediate_parquet_files,
-            output_storage_options=args.output_storage_options,
         )
         self.gather_plan(args)
 
@@ -60,16 +59,12 @@ class SoapPlan(PipelineResumePlan):
                 return
             step_progress.update(1)
 
-            self.object_catalog = Catalog.read_from_hipscat(
-                args.object_catalog_dir, storage_options=args.object_storage_options
-            )
+            self.object_catalog = Catalog.read_from_hipscat(args.object_catalog_dir)
             source_map_file = file_io.append_paths_to_pointer(self.tmp_path, self.SOURCE_MAP_FILE)
             if file_io.does_file_or_directory_exist(source_map_file):
                 source_pixel_map = np.load(source_map_file, allow_pickle=True)["arr_0"].item()
             else:
-                source_catalog = Catalog.read_from_hipscat(
-                    args.source_catalog_dir, storage_options=args.source_storage_options
-                )
+                source_catalog = Catalog.read_from_hipscat(args.source_catalog_dir)
                 source_pixel_map = source_to_object_map(self.object_catalog, source_catalog)
                 np.savez_compressed(source_map_file, source_pixel_map)
             self.count_keys = self.get_sources_to_count(source_pixel_map=source_pixel_map)

--- a/src/hipscat_import/soap/run_soap.py
+++ b/src/hipscat_import/soap/run_soap.py
@@ -50,35 +50,21 @@ def run(args, client):
     # All done - write out the metadata
     with resume_plan.print_progress(total=4, stage_name="Finishing") as step_progress:
         if args.write_leaf_files:
-            total_rows = parquet_metadata.write_parquet_metadata(
-                args.catalog_path,
-                storage_options=args.output_storage_options,
-            )
+            total_rows = parquet_metadata.write_parquet_metadata(args.catalog_path)
             metadata_path = paths.get_parquet_metadata_pointer(args.catalog_path)
-            partition_join_info = PartitionJoinInfo.read_from_file(
-                metadata_path, storage_options=args.output_storage_options
-            )
-            partition_join_info.write_to_csv(
-                catalog_path=args.catalog_path, storage_options=args.output_storage_options
-            )
+            partition_join_info = PartitionJoinInfo.read_from_file(metadata_path)
+            partition_join_info.write_to_csv(catalog_path=args.catalog_path)
         else:
-            total_rows = combine_partial_results(
-                args.tmp_path, args.catalog_path, args.output_storage_options
-            )
+            total_rows = combine_partial_results(args.tmp_path, args.catalog_path)
         step_progress.update(1)
         catalog_info = args.to_catalog_info(total_rows)
         write_metadata.write_provenance_info(
             catalog_base_dir=args.catalog_path,
             dataset_info=catalog_info,
             tool_args=args.provenance_info(),
-            storage_options=args.output_storage_options,
         )
         step_progress.update(1)
-        write_metadata.write_catalog_info(
-            dataset_info=catalog_info,
-            catalog_base_dir=args.catalog_path,
-            storage_options=args.output_storage_options,
-        )
+        write_metadata.write_catalog_info(dataset_info=catalog_info, catalog_base_dir=args.catalog_path)
         step_progress.update(1)
         resume_plan.clean_resume_files()
         step_progress.update(1)

--- a/src/hipscat_import/verification/arguments.py
+++ b/src/hipscat_import/verification/arguments.py
@@ -18,7 +18,7 @@ class VerificationArguments(RuntimeArguments):
     """Data class for holding verification arguments"""
 
     ## Input
-    input_catalog_path: Optional[str | Path | UPath] = None
+    input_catalog_path: str | Path | UPath | None = None
     """Path to an existing catalog that will be inspected."""
     input_catalog: Optional[Catalog] = None
     """In-memory representation of a catalog. If not provided, it will be loaded

--- a/src/hipscat_import/verification/arguments.py
+++ b/src/hipscat_import/verification/arguments.py
@@ -1,10 +1,14 @@
 """Utility to hold all arguments required throughout verification pipeline"""
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import List, Optional
 
 from hipscat.catalog import Catalog
 from hipscat.io.validation import is_valid_catalog
+from upath import UPath
 
 from hipscat_import.runtime_arguments import RuntimeArguments
 
@@ -14,7 +18,7 @@ class VerificationArguments(RuntimeArguments):
     """Data class for holding verification arguments"""
 
     ## Input
-    input_catalog_path: str = ""
+    input_catalog_path: Optional[str | Path | UPath] = None
     """Path to an existing catalog that will be inspected."""
     input_catalog: Optional[Catalog] = None
     """In-memory representation of a catalog. If not provided, it will be loaded

--- a/tests/hipscat_import/catalog/test_argument_validation.py
+++ b/tests/hipscat_import/catalog/test_argument_validation.py
@@ -107,7 +107,7 @@ def test_good_paths(blank_data_dir, blank_data_file, tmp_path):
     )
     assert args.input_path == blank_data_dir
     assert len(args.input_paths) == 1
-    assert str(blank_data_file) in args.input_paths[0]
+    assert str(blank_data_file) in str(args.input_paths[0])
 
 
 def test_multiple_files_in_path(small_sky_parts_dir, tmp_path):

--- a/tests/hipscat_import/catalog/test_argument_validation.py
+++ b/tests/hipscat_import/catalog/test_argument_validation.py
@@ -263,7 +263,6 @@ def test_write_provenance_info(formats_dir, tmp_path):
         catalog_base_dir=args.catalog_path,
         dataset_info=args.to_catalog_info(0),
         tool_args=args.provenance_info(),
-        storage_options=args.output_storage_options,
     )
 
 

--- a/tests/hipscat_import/catalog/test_resume_plan.py
+++ b/tests/hipscat_import/catalog/test_resume_plan.py
@@ -58,15 +58,14 @@ def test_same_input_paths(tmp_path, small_sky_single_file, formats_headers_csv):
             input_paths=[small_sky_single_file, small_sky_single_file],
         )
 
-    ## Includes a duplicate file, but that's ok.
-    plan = ResumePlan(
-        tmp_path=tmp_path,
-        progress_bar=False,
-        resume=True,
-        input_paths=[small_sky_single_file, small_sky_single_file, formats_headers_csv],
-    )
-    map_files = plan.map_files
-    assert len(map_files) == 2
+    ## Includes a duplicate file, and we don't like that.
+    with pytest.raises(ValueError, match="Different file set"):
+        ResumePlan(
+            tmp_path=tmp_path,
+            progress_bar=False,
+            resume=True,
+            input_paths=[small_sky_single_file, small_sky_single_file, formats_headers_csv],
+        )
 
 
 def test_read_write_histogram(tmp_path):

--- a/tests/hipscat_import/margin_cache/test_margin_cache.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache.py
@@ -7,6 +7,7 @@ import pytest
 from hipscat.catalog import PartitionInfo
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset
 from hipscat.io import paths
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 import hipscat_import.margin_cache.margin_cache as mc
 from hipscat_import.margin_cache.margin_cache_arguments import MarginCacheArguments
@@ -31,7 +32,7 @@ def test_margin_cache_gen(small_sky_source_catalog, tmp_path, dask_client):
     norder = 1
     npix = 47
 
-    test_file = paths.pixel_catalog_file(args.catalog_path, norder, npix)
+    test_file = paths.pixel_catalog_file(args.catalog_path, HealpixPixel(norder, npix))
 
     data = pd.read_parquet(test_file)
 
@@ -92,7 +93,7 @@ def test_margin_cache_gen_negative_pixels(small_sky_source_catalog, tmp_path, da
     norder = 0
     npix = 7
 
-    negative_test_file = paths.pixel_catalog_file(args.catalog_path, norder, npix)
+    negative_test_file = paths.pixel_catalog_file(args.catalog_path, HealpixPixel(norder, npix))
 
     negative_data = pd.read_parquet(negative_test_file)
 

--- a/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
@@ -81,7 +81,7 @@ def test_map_pixel_shards_error(tmp_path, capsys):
     catalog parquet files."""
     with pytest.raises(FileNotFoundError):
         margin_cache_map_reduce.map_pixel_shards(
-            paths.pixel_catalog_file(tmp_path, 1, 0),
+            paths.pixel_catalog_file(tmp_path, HealpixPixel(1, 0)),
             mapping_key="1_21",
             input_storage_options=None,
             original_catalog_metadata="",
@@ -95,7 +95,7 @@ def test_map_pixel_shards_error(tmp_path, capsys):
         )
 
     captured = capsys.readouterr()
-    assert "No such file or directory" in captured.out
+    assert "Parquet file does not exist" in captured.out
 
 
 @pytest.mark.timeout(30)
@@ -166,8 +166,8 @@ def test_reduce_margin_shards(tmp_path):
     os.makedirs(shard_dir)
     os.makedirs(intermediate_dir / "reducing")
 
-    first_shard_path = paths.pixel_catalog_file(partition_dir, 1, 0)
-    second_shard_path = paths.pixel_catalog_file(partition_dir, 1, 1)
+    first_shard_path = paths.pixel_catalog_file(partition_dir, HealpixPixel(1, 0))
+    second_shard_path = paths.pixel_catalog_file(partition_dir, HealpixPixel(1, 1))
 
     ras = np.arange(0.0, 360.0)
     dec = np.full(360, 0.0)
@@ -216,7 +216,7 @@ def test_reduce_margin_shards(tmp_path):
         input_storage_options=None,
     )
 
-    result_path = paths.pixel_catalog_file(tmp_path, 1, 21)
+    result_path = paths.pixel_catalog_file(tmp_path, HealpixPixel(1, 21))
 
     validate_result_dataframe(result_path, 720)
     assert os.path.exists(shard_dir)
@@ -234,7 +234,7 @@ def test_reduce_margin_shards(tmp_path):
         input_storage_options=None,
     )
 
-    result_path = paths.pixel_catalog_file(tmp_path, 1, 21)
+    result_path = paths.pixel_catalog_file(tmp_path, HealpixPixel(1, 21))
 
     validate_result_dataframe(result_path, 720)
     assert not os.path.exists(shard_dir)
@@ -252,8 +252,8 @@ def test_reduce_margin_shards_error(tmp_path, basic_data_shard_df, capsys):
     # Don't write anything at the metadata path!
     schema_path = tmp_path / "metadata.parquet"
 
-    basic_data_shard_df.to_parquet(paths.pixel_catalog_file(partition_dir, 1, 0))
-    basic_data_shard_df.to_parquet(paths.pixel_catalog_file(partition_dir, 1, 1))
+    basic_data_shard_df.to_parquet(paths.pixel_catalog_file(partition_dir, HealpixPixel(1, 0)))
+    basic_data_shard_df.to_parquet(paths.pixel_catalog_file(partition_dir, HealpixPixel(1, 1)))
 
     with pytest.raises(FileNotFoundError):
         margin_cache_map_reduce.reduce_margin_shards(
@@ -269,4 +269,4 @@ def test_reduce_margin_shards_error(tmp_path, basic_data_shard_df, capsys):
         )
 
     captured = capsys.readouterr()
-    assert "No such file or directory" in captured.out
+    assert "Parquet file does not exist" in captured.out

--- a/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
+++ b/tests/hipscat_import/margin_cache/test_margin_cache_map_reduce.py
@@ -83,7 +83,6 @@ def test_map_pixel_shards_error(tmp_path, capsys):
         margin_cache_map_reduce.map_pixel_shards(
             paths.pixel_catalog_file(tmp_path, HealpixPixel(1, 0)),
             mapping_key="1_21",
-            input_storage_options=None,
             original_catalog_metadata="",
             margin_pair_file="",
             margin_threshold=10,
@@ -106,7 +105,6 @@ def test_map_pixel_shards_fine(tmp_path, test_data_dir, small_sky_source_catalog
     margin_cache_map_reduce.map_pixel_shards(
         small_sky_source_catalog / "Norder=1" / "Dir=0" / "Npix=47.parquet",
         mapping_key="1_47",
-        input_storage_options=None,
         original_catalog_metadata=small_sky_source_catalog / "_common_metadata",
         margin_pair_file=test_data_dir / "margin_pairs" / "small_sky_source_pairs.csv",
         margin_threshold=3600,
@@ -136,7 +134,6 @@ def test_map_pixel_shards_coarse(tmp_path, test_data_dir, small_sky_source_catal
     margin_cache_map_reduce.map_pixel_shards(
         small_sky_source_catalog / "Norder=1" / "Dir=0" / "Npix=47.parquet",
         mapping_key="1_47",
-        input_storage_options=None,
         original_catalog_metadata=small_sky_source_catalog / "_common_metadata",
         margin_pair_file=test_data_dir / "margin_pairs" / "small_sky_source_pairs.csv",
         margin_threshold=3600,
@@ -208,12 +205,10 @@ def test_reduce_margin_shards(tmp_path):
         intermediate_dir,
         "1_21",
         tmp_path,
-        None,
         1,
         21,
         original_catalog_metadata=schema_path,
         delete_intermediate_parquet_files=False,
-        input_storage_options=None,
     )
 
     result_path = paths.pixel_catalog_file(tmp_path, HealpixPixel(1, 21))
@@ -226,12 +221,10 @@ def test_reduce_margin_shards(tmp_path):
         intermediate_dir,
         "1_21",
         tmp_path,
-        None,
         1,
         21,
         original_catalog_metadata=schema_path,
         delete_intermediate_parquet_files=True,
-        input_storage_options=None,
     )
 
     result_path = paths.pixel_catalog_file(tmp_path, HealpixPixel(1, 21))
@@ -260,12 +253,10 @@ def test_reduce_margin_shards_error(tmp_path, basic_data_shard_df, capsys):
             intermediate_dir,
             "1_21",
             tmp_path,
-            None,
             1,
             21,
             original_catalog_metadata=schema_path,
             delete_intermediate_parquet_files=True,
-            input_storage_options=None,
         )
 
     captured = capsys.readouterr()

--- a/tests/hipscat_import/margin_cache/test_margin_round_trip.py
+++ b/tests/hipscat_import/margin_cache/test_margin_round_trip.py
@@ -8,6 +8,7 @@ import pytest
 from hipscat.catalog.catalog import Catalog
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset
 from hipscat.io import paths
+from hipscat.pixel_math.healpix_pixel import HealpixPixel
 
 import hipscat_import.catalog.run_import as runner
 import hipscat_import.margin_cache.margin_cache as mc
@@ -68,7 +69,7 @@ def test_margin_import_gaia_minimum(
     norder = 0
     npix = 0
 
-    test_file = paths.pixel_catalog_file(args.catalog_path, norder, npix)
+    test_file = paths.pixel_catalog_file(args.catalog_path, HealpixPixel(norder, npix))
 
     data = pd.read_parquet(test_file)
 
@@ -122,7 +123,7 @@ def test_margin_import_mixed_schema_csv(
     norder = 2
     npix = 187
 
-    test_file = paths.pixel_catalog_file(args.catalog_path, norder, npix)
+    test_file = paths.pixel_catalog_file(args.catalog_path, HealpixPixel(norder, npix))
 
     data = pd.read_parquet(test_file)
 

--- a/tests/hipscat_import/soap/test_soap_map_reduce.py
+++ b/tests/hipscat_import/soap/test_soap_map_reduce.py
@@ -117,7 +117,7 @@ def test_combine_results(tmp_path):
     partitions_csv_file = input_path / "0_11.csv"
     join_info.to_csv(partitions_csv_file, index=False)
 
-    total_num_rows = combine_partial_results(input_path, output_path, None)
+    total_num_rows = combine_partial_results(input_path, output_path)
     assert total_num_rows == 131
 
     result = pd.read_csv(output_path / "partition_join_info.csv")

--- a/tests/hipscat_import/verification/test_verification_arguments.py
+++ b/tests/hipscat_import/verification/test_verification_arguments.py
@@ -62,7 +62,7 @@ def test_catalog_object(tmp_path, small_sky_object_catalog):
         output_path=tmp_path,
         output_artifact_name="small_sky_object_verification_report",
     )
-    assert args.input_catalog_path == str(small_sky_object_catalog)
+    assert args.input_catalog_path == small_sky_object_catalog
     assert str(args.output_path) == tmp_path_str
     assert str(args.tmp_path).startswith(tmp_path_str)
 


### PR DESCRIPTION
See https://github.com/astronomy-commons/hipscat/pull/336

## Solution Description

Use fsspec's project, [universal-pathlib](https://github.com/fsspec/universal_pathlib) as a path provider. In this way, everywhere we currently pass in a `FilePointer` we can use a `Path` instead, and when we need to create remote connections, use `UPath`.