### PR TITLE
Style follow-up on run_conversion.py

### DIFF
--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -51,10 +51,9 @@ def run(args: ConversionArguments, client):
         )
         catalog_info["hats_builder"] = builder_str
         if runtime_args := provenance_info["tool_args"].get("runtime_args"):
-            runtime_args = provenance_info["tool_args"]["runtime_args"]
             catalog_info["hats_cols_sort"] = runtime_args.get("sort_columns")
-            catalog_info["hats_cols_survey_id"] = runtime_args.get("sort_columns", None)
-            catalog_info["hats_max_rows"] = runtime_args.get("pixel_threshold", None)
+            catalog_info["hats_cols_survey_id"] = runtime_args.get("sort_columns")
+            catalog_info["hats_max_rows"] = runtime_args.get("pixel_threshold")
 
     partition_info = PartitionInfo.read_from_dir(args.input_catalog_path)
     catalog_info["hats_order"] = partition_info.get_highest_order()


### PR DESCRIPTION
<!-- 
Thank you for your contribution to the repo :)

Pull Request (PR) Instructions:
Provide a general summary of your changes in the Title above. Fill out each section of the template, and replace the space with an `x` in all the boxes that apply. If you're unsure about any of these, don't hesitate to ask. We're here to help! Once you are satisfied with the pull request, click the "Create pull request" button to submit it for review.

Before submitting this PR, please ensure that your input and responses are entered in the designated space provided below each section to keep all project-related information organized and easily accessible.
 
How to link to a PR:
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue 
-->

## Change Description
<!--- 
Describe your changes in detail. In your description, you should answer questions like "Why is this change required? What problem does it solve?".

If it fixes an open issue, please link to the issue here. If this PR closes an issue, put the word 'closes' before the issue link to auto-close the issue when the PR is merged.
-->
In a former PR, https://github.com/astronomy-commons/hipscat-import/pull/392, I made a suggestion to use the `:=` operator.  This obviates the line following, but I wasn't able to make that line deletion part of my suggestion.  This PR follows up on that suggestion, as well as defaulting the other `None` arguments to `.get()` in the following clause.

## Code Quality
- [X] I have read the [Contribution Guide](https://hipscat-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
