### PR TITLE
Test for existence of new hats.properties file.

### DIFF
--- a/tests/hats_import/catalog/test_run_round_trip.py
+++ b/tests/hats_import/catalog/test_run_round_trip.py
@@ -659,6 +659,19 @@ def test_import_lowest_healpix_order(
     assert catalog.catalog_info.skymap_alt_orders == [1, 3]
     assert catalog.catalog_info.skymap_order == 4
 
+    old_properties_file = args.catalog_path / "properties"
+    assert old_properties_file.exists()
+    new_properties_file = args.catalog_path / "hats.properties"
+    assert new_properties_file.exists()
+
+    with open(old_properties_file, "r", encoding="utf-8") as old_file:
+        old_contents = old_file.readlines()
+
+    with open(new_properties_file, "r", encoding="utf-8") as new_file:
+        new_contents = new_file.readlines()
+
+    assert old_contents == new_contents
+
 
 class StarrReader(CsvReader):
     """Shallow subclass"""

--- a/tests/hats_import/conftest.py
+++ b/tests/hats_import/conftest.py
@@ -8,7 +8,7 @@ import numpy as np
 import numpy.testing as npt
 import pandas as pd
 import pytest
-from dask.distributed import Client
+from dask.distributed import Client, LocalCluster
 from hats import pixel_math
 
 # pylint: disable=missing-function-docstring, redefined-outer-name
@@ -17,9 +17,11 @@ from hats import pixel_math
 @pytest.fixture(scope="session", name="dask_client")
 def dask_client():
     """Create a single client for use by all unit test cases."""
-    client = Client(n_workers=1, threads_per_worker=1)
+    cluster = LocalCluster(n_workers=1, threads_per_worker=1, dashboard_address=":0")
+    client = Client(cluster)
     yield client
     client.close()
+    cluster.close()
 
 
 def pytest_collection_modifyitems(items):


### PR DESCRIPTION
Closes #547 

Also sneaks in a change to the suite-wide dask client that makes the cluster headless. We don't get warnings like this anymore:

```
tests/hats_import/catalog/test_run_round_trip.py::test_import_lowest_healpix_order
  /home/delucchi/.virtualenvs/june/lib/python3.12/site-packages/distributed/node.py:187: UserWarning: Port 8787 is already in use.
  Perhaps you already have a cluster running?
  Hosting the HTTP server on port 43973 instead
    warnings.warn(
```