### PR TITLE
Support importing empty margins

### DIFF
--- a/src/hats_import/margin_cache/margin_cache.py
+++ b/src/hats_import/margin_cache/margin_cache.py
@@ -1,6 +1,6 @@
+import pyarrow.parquet as pq
 from hats.catalog import PartitionInfo
 from hats.io import file_io, parquet_metadata, paths
-import pyarrow.parquet as pq
 
 import hats_import.margin_cache.margin_cache_map_reduce as mcmr
 from hats_import.margin_cache.margin_cache_resume_plan import MarginCachePlan
@@ -76,12 +76,8 @@ def generate_margin_cache(args, client):
             metadata_path = paths.get_parquet_metadata_pointer(args.catalog_path)
             common_metadata_path = paths.get_common_metadata_pointer(args.catalog_path)
             file_io.make_directory(metadata_path.parent, exist_ok=True)
-            pq.write_metadata(
-                schema, metadata_path.path, filesystem=metadata_path.fs
-            )
-            pq.write_metadata(
-                schema, common_metadata_path.path, filesystem=common_metadata_path.fs
-            )
+            pq.write_metadata(schema, metadata_path.path, filesystem=metadata_path.fs)
+            pq.write_metadata(schema, common_metadata_path.path, filesystem=common_metadata_path.fs)
 
             step_progress.update(1)
 
@@ -93,7 +89,11 @@ def generate_margin_cache(args, client):
         partition_info.write_to_file(partition_info_file)
         step_progress.update(1)
 
-        highest_order = args.catalog.partition_info.get_highest_order() if total_rows == 0 else partition_info.get_highest_order()
+        highest_order = (
+            args.catalog.partition_info.get_highest_order()
+            if total_rows == 0
+            else partition_info.get_highest_order()
+        )
 
         margin_catalog_info = args.to_table_properties(
             int(total_rows),

--- a/tests/hats_import/margin_cache/test_margin_cache.py
+++ b/tests/hats_import/margin_cache/test_margin_cache.py
@@ -125,14 +125,15 @@ def test_generate_empty_margin_catalog(small_sky_object_catalog, tmp_path, dask_
     assert (args.catalog_path / "partition_info.csv").exists()
     assert (args.catalog_path / "hats.properties").exists()
 
-    metadata_path = (args.catalog_path / "dataset" / "_metadata")
-    common_metadata_path = (args.catalog_path / "dataset" / "_common_metadata")
+    metadata_path = args.catalog_path / "dataset" / "_metadata"
+    common_metadata_path = args.catalog_path / "dataset" / "_common_metadata"
     assert metadata_path.exists()
     assert common_metadata_path.exists()
 
     # Verify that the catalog contains no data files
     data_files = [
-        f for f in (args.catalog_path / "dataset").rglob("*")
+        f
+        for f in (args.catalog_path / "dataset").rglob("*")
         if f.is_file() and f not in (metadata_path, common_metadata_path)
     ]
     assert len(list(data_files)) == 0
@@ -147,7 +148,6 @@ def test_generate_empty_margin_catalog(small_sky_object_catalog, tmp_path, dask_
     assert common_metadata.num_rows == 0
     assert common_metadata.num_row_groups == 0
     assert common_metadata.schema.to_arrow_schema() == object_cat.schema
-
 
 
 @pytest.mark.dask(timeout=150)


### PR DESCRIPTION
Writes empty margin catalogs with no parquet leaf files, empty parquet metadata files, and valid hats metadata. This allows users to perform crossmatches with sparse catalogs without warnings.

Closes astronomy-commons/lsdb#867