### PR TITLE
Relax pixel_threshold limits

### DIFF
--- a/src/hats_import/catalog/arguments.py
+++ b/src/hats_import/catalog/arguments.py
@@ -119,8 +119,8 @@ class ImportArguments(RuntimeArguments):
             check_healpix_order_range(
                 self.lowest_healpix_order, "lowest_healpix_order", upper_bound=self.highest_healpix_order
             )
-            if not 100 <= self.pixel_threshold <= 1_000_000_000:
-                raise ValueError("pixel_threshold should be between 100 and 1,000,000,000")
+            if not isinstance(self.pixel_threshold, int) or self.pixel_threshold < 1:
+                raise ValueError("pixel_threshold must be a positive integer")
             self.mapping_healpix_order = self.highest_healpix_order
 
         if self.existing_pixels:

--- a/tests/hats_import/catalog/test_argument_validation.py
+++ b/tests/hats_import/catalog/test_argument_validation.py
@@ -172,7 +172,15 @@ def test_healpix_args(blank_data_dir, tmp_path):
             input_path=blank_data_dir,
             file_reader="csv",
             output_path=tmp_path,
-            pixel_threshold=3,
+            pixel_threshold=-3,
+        )
+    with pytest.raises(ValueError, match="pixel_threshold"):
+        ImportArguments(
+            output_artifact_name="catalog",
+            input_path=blank_data_dir,
+            file_reader="csv",
+            output_path=tmp_path,
+            pixel_threshold="three",
         )
     with pytest.raises(ValueError, match="constant_healpix_order"):
         ImportArguments(


### PR DESCRIPTION
Closes #658 

`pixel_threshold` must be a positive integer. Anything else is fine.