### PR TITLE
Allow newer dask versions, with 3.11 restriction

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11.8', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11.8', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v6
@@ -45,7 +45,7 @@ jobs:
     - name: Set up Python 3.11
       uses: actions/setup-python@v6
       with:
-        python-version: '3.11'
+        python-version: '3.11.8'
     - name: Install dependencies
       run: |
         sudo apt-get update

--- a/.github/workflows/testing-windows.yml
+++ b/.github/workflows/testing-windows.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        python-version: ['3.11']
+        python-version: ['3.11.8']
 
     steps:
     - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
     "cloudpickle>=3.0.0", # Reader serialisation, transitive dependency of Dask
-    "dask[complete]>=2025.3.0,<2025.4.0", # Includes dask expressions.
+    "dask[complete]>=2025.3.0", # Includes dask expressions.
     "deprecated",
     "hats>=0.7.3,<0.8",
     "nested-pandas>=0.6.3,<0.7.0",


### PR DESCRIPTION
There's a hanging bit inside dask expressions, but only under python 3.11. This also happened in LSDB when we rolled forward to dask expressions, but 3.11.8 seemed unharmed.