### PR TITLE
Use Path methods, where appropriate.

### DIFF
--- a/src/hats_import/catalog/file_readers/input_reader.py
+++ b/src/hats_import/catalog/file_readers/input_reader.py
@@ -28,8 +28,6 @@ class InputReader(abc.ABC):
         input_file = file_io.get_upath(input_file)
         if not input_file.exists():
             raise FileNotFoundError(f"File not found at path: {input_file}")
-        if input_file.is_dir():
-            raise FileNotFoundError(f"Directory found at path - requires regular file: {input_file}")
         return input_file
 
     def read_index_file(self, input_file, upath_kwargs=None, **kwargs):

--- a/src/hats_import/catalog/file_readers/input_reader.py
+++ b/src/hats_import/catalog/file_readers/input_reader.py
@@ -26,9 +26,9 @@ class InputReader(abc.ABC):
             FileNotFoundError: if nothing exists at path, or directory found.
         """
         input_file = file_io.get_upath(input_file)
-        if not file_io.does_file_or_directory_exist(input_file):
+        if not input_file.exists():
             raise FileNotFoundError(f"File not found at path: {input_file}")
-        if not file_io.is_regular_file(input_file):
+        if input_file.is_dir():
             raise FileNotFoundError(f"Directory found at path - requires regular file: {input_file}")
         return input_file
 

--- a/src/hats_import/catalog/resume_plan.py
+++ b/src/hats_import/catalog/resume_plan.py
@@ -225,7 +225,7 @@ class ResumePlan(PipelineResumePlan):
         file_name = file_io.append_paths_to_pointer(self.tmp_path, histogram_binary_file)
 
         # If no file, read the histogram from partial histograms and combine.
-        if not file_io.does_file_or_directory_exist(file_name):
+        if not file_name.exists():
             remaining_map_files = self.get_remaining_map_keys(which_histogram=which_histogram)
             if len(remaining_map_files) > 0:
                 raise RuntimeError(f"{len(remaining_map_files)} map stages did not complete successfully.")
@@ -358,7 +358,7 @@ class ResumePlan(PipelineResumePlan):
             path to cached alignment file.
         """
         file_name = file_io.append_paths_to_pointer(self.tmp_path, self.ALIGNMENT_FILE)
-        if not file_io.does_file_or_directory_exist(file_name):
+        if not file_name.exists():
             # If existing_pixels, create an incremental alignment.
             if existing_pixels:
                 alignment = pixel_math.generate_incremental_alignment(

--- a/src/hats_import/margin_cache/margin_cache_map_reduce.py
+++ b/src/hats_import/margin_cache/margin_cache_map_reduce.py
@@ -115,7 +115,7 @@ def reduce_margin_shards(
         healpix_pixel = HealpixPixel(partition_order, partition_pixel)
         shard_dir = get_pixel_cache_directory(intermediate_directory, healpix_pixel)
 
-        if file_io.does_file_or_directory_exist(shard_dir):
+        if shard_dir.exists():
             margin_table = ds.dataset(shard_dir.path, filesystem=shard_dir.fs, format="parquet").to_table()
 
             if len(margin_table):

--- a/src/hats_import/margin_cache/margin_cache_resume_plan.py
+++ b/src/hats_import/margin_cache/margin_cache_resume_plan.py
@@ -47,7 +47,7 @@ class MarginCachePlan(PipelineResumePlan):
             negative_pixels = args.catalog.generate_negative_tree_pixels()
             self.combined_pixels = self.partition_pixels + negative_pixels
             self.margin_pair_file = file_io.append_paths_to_pointer(self.tmp_path, self.MARGIN_PAIR_FILE)
-            if not file_io.does_file_or_directory_exist(self.margin_pair_file):
+            if not self.margin_pair_file.exists():
                 margin_pairs = _find_partition_margin_pixel_pairs(self.combined_pixels, args.margin_order)
                 margin_pairs.to_csv(self.margin_pair_file, index=False)
             step_progress.update(1)
@@ -94,7 +94,7 @@ class MarginCachePlan(PipelineResumePlan):
 
         total_marker_file = file_io.append_paths_to_pointer(self.tmp_path, self.MAPPING_TOTAL_FILE)
 
-        if file_io.does_file_or_directory_exist(total_marker_file):
+        if total_marker_file.exists():
             marker_value = file_io.load_text_file(total_marker_file)
             return _marker_value_to_int(marker_value)
 

--- a/src/hats_import/pipeline_resume_plan.py
+++ b/src/hats_import/pipeline_resume_plan.py
@@ -71,9 +71,7 @@ class PipelineResumePlan:
         Returns:
             boolean, True if the done file exists at tmp_path. False otherwise.
         """
-        return file_io.does_file_or_directory_exist(
-            file_io.append_paths_to_pointer(self.tmp_path, f"{stage_name}_done")
-        )
+        return file_io.append_paths_to_pointer(self.tmp_path, f"{stage_name}_done").exists()
 
     def touch_stage_done_file(self, stage_name):
         """Touch (create) a done file for a whole pipeline stage.

--- a/tests/hats_import/catalog/test_file_readers.py
+++ b/tests/hats_import/catalog/test_file_readers.py
@@ -39,12 +39,10 @@ def test_unknown_file_type():
         get_file_reader("unknown")
 
 
-def test_file_exists(small_sky_dir):
+def test_file_exists():
     """File reader factory method should fail for missing files or directories"""
     with pytest.raises(FileNotFoundError, match="File not found"):
         next(CsvReader().read("foo_not_really_a_path"))
-    with pytest.raises(FileNotFoundError, match="Directory found at path"):
-        next(CsvReader().read(small_sky_dir))
 
 
 def test_csv_reader(small_sky_single_file):

--- a/tests/hats_import/catalog/test_map_reduce.py
+++ b/tests/hats_import/catalog/test_map_reduce.py
@@ -57,7 +57,7 @@ def test_read_wrong_fileformat(small_sky_file0, tmp_path):
 
 def test_read_directory(test_data_dir, tmp_path):
     """Provide directory, not file"""
-    with pytest.raises():
+    with pytest.raises(OSError):
         mr.map_to_pixels(
             input_file=test_data_dir,
             pickled_reader_file=pickle_file_reader(tmp_path, get_file_reader("parquet")),

--- a/tests/hats_import/catalog/test_map_reduce.py
+++ b/tests/hats_import/catalog/test_map_reduce.py
@@ -57,7 +57,7 @@ def test_read_wrong_fileformat(small_sky_file0, tmp_path):
 
 def test_read_directory(test_data_dir, tmp_path):
     """Provide directory, not file"""
-    with pytest.raises(FileNotFoundError):
+    with pytest.raises(OSError, match="is a directory"):
         mr.map_to_pixels(
             input_file=test_data_dir,
             pickled_reader_file=pickle_file_reader(tmp_path, get_file_reader("parquet")),

--- a/tests/hats_import/catalog/test_map_reduce.py
+++ b/tests/hats_import/catalog/test_map_reduce.py
@@ -57,7 +57,7 @@ def test_read_wrong_fileformat(small_sky_file0, tmp_path):
 
 def test_read_directory(test_data_dir, tmp_path):
     """Provide directory, not file"""
-    with pytest.raises(OSError, match="is a directory"):
+    with pytest.raises():
         mr.map_to_pixels(
             input_file=test_data_dir,
             pickled_reader_file=pickle_file_reader(tmp_path, get_file_reader("parquet")),


### PR DESCRIPTION
`is_regular_file` can be misleading, when pointing to an HTTP directory, and this is working as intended. Since the check is for finding a directory, `is_dir` is more appropriate.

The `is_regular_file` method is just a thin wrapper around path methods (as is `does_file_or_directory_exist`), so this PR uses those simple path methods, so the `file_io` methods can be removed later.