### PR TITLE
Constrain dask versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,9 @@ dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = [
     "cloudpickle>=3.0.0", # Reader serialisation, transitive dependency of Dask
-    "dask[complete]>=2025.3.0,<2025.4.0", # Includes dask expressions.
+    # Odd regression for newer dask under python 3.11 only.
+    "dask[complete]>=2025.3.0,<2025.4.0; python_version=='3.11'",
+    "dask[complete]>=2025.3.0; python_version != '3.11'",
     "deprecated",
     "hats>=0.7.3,<0.8",
     "nested-pandas>=0.6.3,<0.7.0",


### PR DESCRIPTION
There is an odd regression in performance in newer versions of dask, but only under python=3.11. This allows all other versions of python to use newer versions of dask.