### PR TITLE
Change default parquet reader

### DIFF
--- a/docs/catalogs/public/zubercal.rst
+++ b/docs/catalogs/public/zubercal.rst
@@ -34,14 +34,14 @@ Challenges with this data set
 
     import hats_import.pipeline as runner
     from hats_import.catalog.arguments import ImportArguments
-    from hats_import.catalog.file_readers import ParquetReader
+    from hats_import.catalog.file_readers import ParquetPandasReader
     import pyarrow.parquet as pq
     import pyarrow as pa
     import re
     import glob
 
 
-    class ZubercalParquetReader(ParquetReader):
+    class ZubercalParquetReader(ParquetPandasReader):
         def read(self, input_file):
             """Reader for the specifics of zubercal parquet files."""
             columns = [

--- a/docs/reference/file_readers.rst
+++ b/docs/reference/file_readers.rst
@@ -86,7 +86,7 @@ Built-in Classes and Functions
     CsvReader
     CsvPyarrowReader
     IndexedCsvReader
-    ParquetReader
+    ParquetPandasReader
     ParquetPyarrowReader
     IndexedParquetReader 
     AstropyEcsvReader

--- a/src/hats_import/catalog/file_readers/__init__.py
+++ b/src/hats_import/catalog/file_readers/__init__.py
@@ -4,7 +4,7 @@ from .csv import CsvPyarrowReader, CsvReader, IndexedCsvReader
 from .ecsv import AstropyEcsvReader
 from .fits import FitsReader
 from .input_reader import InputReader
-from .parquet import IndexedParquetReader, ParquetPyarrowReader, ParquetReader
+from .parquet import IndexedParquetReader, ParquetPandasReader, ParquetPyarrowReader
 
 
 def get_file_reader(
@@ -64,7 +64,7 @@ def get_file_reader(
             **kwargs,
         )
     if file_format == "parquet":
-        return ParquetReader(chunksize=chunksize, **kwargs)
+        return ParquetPyarrowReader(chunksize=chunksize, column_names=column_names, **kwargs)
     if file_format == "indexed_csv":
         return IndexedCsvReader(
             chunksize=chunksize,

--- a/src/hats_import/catalog/file_readers/__init__.py
+++ b/src/hats_import/catalog/file_readers/__init__.py
@@ -64,7 +64,7 @@ def get_file_reader(
             **kwargs,
         )
     if file_format == "parquet":
-        return ParquetPyarrowReader(chunksize=chunksize, column_names=column_names, **kwargs)
+        return ParquetPyarrowReader(chunksize=chunksize, **kwargs)
     if file_format == "indexed_csv":
         return IndexedCsvReader(
             chunksize=chunksize,

--- a/src/hats_import/catalog/file_readers/parquet.py
+++ b/src/hats_import/catalog/file_readers/parquet.py
@@ -4,8 +4,10 @@ from hats.io import file_io
 from hats_import.catalog.file_readers.input_reader import InputReader
 
 
-class ParquetReader(InputReader):
+class ParquetPandasReader(InputReader):
     """Parquet reader for the most common Parquet reading arguments.
+
+    Reads input file as a pandas.DataFrame.
 
     Attributes:
         chunksize (int): number of rows of the file to process at once.
@@ -34,6 +36,8 @@ class ParquetReader(InputReader):
 
 class ParquetPyarrowReader(InputReader):
     """Parquet reader that uses the pyarrow library for reading.
+
+    Reads file as a pyarrow.Table.
 
     Attributes:
         chunksize (int): number of rows of the file to process at once.

--- a/tests/hats_import/catalog/test_file_readers.py
+++ b/tests/hats_import/catalog/test_file_readers.py
@@ -13,7 +13,7 @@ from hats_import.catalog.file_readers import (
     FitsReader,
     IndexedCsvReader,
     IndexedParquetReader,
-    ParquetReader,
+    ParquetPyarrowReader,
     get_file_reader,
 )
 
@@ -269,7 +269,7 @@ def test_indexed_csv_reader(indexed_files_dir):
 def test_parquet_reader(parquet_shards_shard_44_0):
     """Verify we can read the parquet file into a single data frame."""
     total_chunks = 0
-    for frame in ParquetReader().read(parquet_shards_shard_44_0):
+    for frame in ParquetPyarrowReader().read(parquet_shards_shard_44_0):
         total_chunks += 1
         assert len(frame) == 7
 
@@ -279,7 +279,7 @@ def test_parquet_reader(parquet_shards_shard_44_0):
 def test_parquet_reader_chunked(parquet_shards_shard_44_0):
     """Verify we can read the parquet file into a single data frame."""
     total_chunks = 0
-    for frame in ParquetReader(chunksize=1).read(parquet_shards_shard_44_0):
+    for frame in ParquetPyarrowReader(chunksize=1).read(parquet_shards_shard_44_0):
         total_chunks += 1
         assert len(frame) == 1
     assert total_chunks == 7
@@ -318,12 +318,12 @@ def test_parquet_reader_columns(parquet_shards_shard_44_0):
     column_subset = ["id", "dec"]
 
     # test column_names class property
-    for frame in ParquetReader(column_names=column_subset).read(parquet_shards_shard_44_0):
-        assert set(frame.columns) == set(column_subset)
+    for frame in ParquetPyarrowReader(column_names=column_subset).read(parquet_shards_shard_44_0):
+        assert set(frame.column_names) == set(column_subset)
 
     # test read_columns kwarg
-    for frame in ParquetReader().read(parquet_shards_shard_44_0, read_columns=column_subset):
-        assert set(frame.columns) == set(column_subset)
+    for frame in ParquetPyarrowReader().read(parquet_shards_shard_44_0, read_columns=column_subset):
+        assert set(frame.column_names) == set(column_subset)
 
 
 def test_read_fits(formats_fits):


### PR DESCRIPTION
The current default parquet reader ingests the input files as pandas DataFrames. The conversion to a pandas-compatible dataframe can bring inconsistencies in data types, especially when null values are present. This PR changes the default reader to the `PyarrowParquetReader` which already exists in our code base and that only uses the `pyarrow.parquet` library. All tests seem to pass.

## Code Quality
- [X] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [X] My code follows the code style of this project
- [X] My code builds (or compiles) cleanly without any errors or warnings
- [X] My code contains relevant comments and necessary documentation
