### PR TITLE
Make i/o tracing a little easier.

### DIFF
--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -16,6 +16,7 @@ from hats.pixel_math.sparse_histogram import HistogramAggregator, supplemental_c
 from hats.pixel_math.spatial_index import SPATIAL_INDEX_COLUMN, spatial_index_to_healpix
 from upath import UPath
 
+import hats_import.file_io as import_io
 from hats_import.catalog.resume_plan import ResumePlan
 from hats_import.pipeline_resume_plan import get_pixel_cache_directory, print_task_failure
 
@@ -203,7 +204,7 @@ def split_pixels(
                 pixel = pixel_alignment_count[1]
                 pixel_dir = get_pixel_cache_directory(cache_shard_path, HealpixPixel(order, pixel))
                 file_io.make_directory(pixel_dir, exist_ok=True)
-                output_file = file_io.append_paths_to_pointer(
+                output_file = import_io.append_paths_to_pointer(
                     pixel_dir, f"shard_{splitting_key}_{chunk_number}.parquet"
                 )
                 if isinstance(data, pd.DataFrame):

--- a/src/hats_import/file_io.py
+++ b/src/hats_import/file_io.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from hats.io.file_io import get_upath
+from upath import UPath
+
+
+def append_paths_to_pointer(pointer: str | Path | UPath, *paths: str) -> UPath:
+    """Append directories and/or a file name to a specified file pointer.
+
+    Parameters
+    ----------
+    pointer : str | Path | UPath
+        `FilePointer` object to add path to
+    *paths: str
+        any number of directory names optionally followed by a file name to append to the
+        pointer
+
+    Returns
+    -------
+    UPath
+        New file pointer to path given by joining given pointer and path names
+    """
+    pointer = get_upath(pointer)
+    return pointer.joinpath(*paths)
+
+
+def find_files_matching_path(pointer: str | Path | UPath, *paths: str) -> list[UPath]:
+    """Find files or directories matching the provided path parts.
+
+    Parameters
+    ----------
+    pointer : str | Path | UPath
+        base File Pointer in which to find contents
+    *paths: str
+        any number of directory names optionally followed by a file name.
+        directory or file names may be replaced with `*` as a matcher.
+
+    Returns
+    -------
+    list[UPath]
+        New file pointers to files found matching the path
+    """
+    pointer = get_upath(pointer)
+
+    if len(paths) == 0:
+        return [pointer]
+
+    matcher = pointer.fs.sep.join(paths)
+    contents = []
+    for child in pointer.rglob(matcher):
+        contents.append(child)
+
+    if len(contents) == 0:
+        return []
+
+    contents.sort()
+    return contents
+
+
+def directory_has_contents(pointer: str | Path | UPath) -> bool:
+    """Checks if a directory already has some contents (any files or subdirectories)
+
+    Parameters
+    ----------
+    pointer : str | Path | UPath
+        File Pointer to check for existing contents
+
+    Returns
+    -------
+    bool
+        True if there are any files or subdirectories below this directory.
+    """
+    pointer = get_upath(pointer)
+
+    return next(pointer.rglob("*"), None) is not None

--- a/src/hats_import/margin_cache/margin_cache_resume_plan.py
+++ b/src/hats_import/margin_cache/margin_cache_resume_plan.py
@@ -9,6 +9,7 @@ from hats import pixel_math
 from hats.io import file_io
 from hats.pixel_math.healpix_pixel import HealpixPixel
 
+import hats_import.file_io as import_io
 from hats_import.margin_cache.margin_cache_arguments import MarginCacheArguments
 from hats_import.pipeline_resume_plan import PipelineResumePlan
 
@@ -46,18 +47,18 @@ class MarginCachePlan(PipelineResumePlan):
             self.partition_pixels = args.catalog.partition_info.get_healpix_pixels()
             negative_pixels = args.catalog.generate_negative_tree_pixels()
             self.combined_pixels = self.partition_pixels + negative_pixels
-            self.margin_pair_file = file_io.append_paths_to_pointer(self.tmp_path, self.MARGIN_PAIR_FILE)
+            self.margin_pair_file = import_io.append_paths_to_pointer(self.tmp_path, self.MARGIN_PAIR_FILE)
             if not self.margin_pair_file.exists():
                 margin_pairs = _find_partition_margin_pixel_pairs(self.combined_pixels, args.margin_order)
                 margin_pairs.to_csv(self.margin_pair_file, index=False)
             step_progress.update(1)
 
             file_io.make_directory(
-                file_io.append_paths_to_pointer(self.tmp_path, self.MAPPING_STAGE),
+                import_io.append_paths_to_pointer(self.tmp_path, self.MAPPING_STAGE),
                 exist_ok=True,
             )
             file_io.make_directory(
-                file_io.append_paths_to_pointer(self.tmp_path, self.REDUCING_STAGE),
+                import_io.append_paths_to_pointer(self.tmp_path, self.REDUCING_STAGE),
                 exist_ok=True,
             )
 
@@ -92,7 +93,7 @@ class MarginCachePlan(PipelineResumePlan):
         if not self.is_mapping_done():
             raise ValueError("mapping stage is not done yet.")
 
-        total_marker_file = file_io.append_paths_to_pointer(self.tmp_path, self.MAPPING_TOTAL_FILE)
+        total_marker_file = import_io.append_paths_to_pointer(self.tmp_path, self.MAPPING_TOTAL_FILE)
 
         if total_marker_file.exists():
             marker_value = file_io.load_text_file(total_marker_file)

--- a/src/hats_import/runtime_arguments.py
+++ b/src/hats_import/runtime_arguments.py
@@ -14,6 +14,8 @@ from hats.io.validation import is_valid_catalog
 from hats.pixel_math import spatial_index
 from upath import UPath
 
+import hats_import.file_io as import_io
+
 # pylint: disable=too-many-instance-attributes
 
 
@@ -119,22 +121,22 @@ class RuntimeArguments:
         file_io.make_directory(self.catalog_path, exist_ok=True)
 
         if self.tmp_dir and str(self.tmp_dir) != str(self.output_path):
-            self.tmp_path = file_io.append_paths_to_pointer(
+            self.tmp_path = import_io.append_paths_to_pointer(
                 self.tmp_dir, self.output_artifact_name, "intermediate"
             )
-            self.tmp_base_path = file_io.append_paths_to_pointer(self.tmp_dir, self.output_artifact_name)
+            self.tmp_base_path = import_io.append_paths_to_pointer(self.tmp_dir, self.output_artifact_name)
         elif self.dask_tmp and str(self.dask_tmp) != str(self.output_path):
-            self.tmp_path = file_io.append_paths_to_pointer(
+            self.tmp_path = import_io.append_paths_to_pointer(
                 self.dask_tmp, self.output_artifact_name, "intermediate"
             )
-            self.tmp_base_path = file_io.append_paths_to_pointer(self.dask_tmp, self.output_artifact_name)
+            self.tmp_base_path = import_io.append_paths_to_pointer(self.dask_tmp, self.output_artifact_name)
         else:
-            self.tmp_path = file_io.append_paths_to_pointer(self.catalog_path, "intermediate")
+            self.tmp_path = import_io.append_paths_to_pointer(self.catalog_path, "intermediate")
         if not self.resume:
             file_io.remove_directory(self.tmp_path, ignore_errors=True)
         file_io.make_directory(self.tmp_path, exist_ok=True)
         if self.resume_tmp:
-            self.resume_tmp = file_io.append_paths_to_pointer(self.resume_tmp, self.output_artifact_name)
+            self.resume_tmp = import_io.append_paths_to_pointer(self.resume_tmp, self.output_artifact_name)
         else:
             self.resume_tmp = self.tmp_path
 
@@ -186,7 +188,7 @@ def find_input_paths(input_path="", file_matcher="", input_file_list=None):
     if input_path:
         if input_file_list:
             raise ValueError("exactly one of input_path or input_file_list is required")
-        input_paths = file_io.find_files_matching_path(input_path, file_matcher)
+        input_paths = import_io.find_files_matching_path(input_path, file_matcher)
     elif input_file_list is not None:
         if pd.api.types.is_list_like(input_file_list):
             # It's common for users to accidentally pass in an empty list. Give them a friendly error.

--- a/src/hats_import/verification/arguments.py
+++ b/src/hats_import/verification/arguments.py
@@ -11,6 +11,8 @@ from hats.catalog import CatalogCollection
 from hats.io import file_io
 from upath import UPath
 
+import hats_import.file_io as import_io
+
 
 @dataclass(kw_only=True)
 class VerificationArguments:
@@ -56,12 +58,12 @@ class VerificationArguments:
     @property
     def input_dataset_path(self) -> UPath:
         """Path to the directory under `input_catalog_path` that contains the parquet dataset."""
-        return file_io.append_paths_to_pointer(self.input_catalog_path, hats.io.paths.DATASET_DIR)
+        return import_io.append_paths_to_pointer(self.input_catalog_path, hats.io.paths.DATASET_DIR)
 
     @property
     def output_file_path(self) -> UPath:
         """Path to the output file (`output_path` / `output_filename`)."""
-        return file_io.append_paths_to_pointer(self.output_path, self.output_filename)
+        return import_io.append_paths_to_pointer(self.output_path, self.output_filename)
 
     def __post_init__(self) -> None:
         self.input_catalog_path = file_io.get_upath(self.input_catalog_path)
@@ -75,6 +77,6 @@ class VerificationArguments:
         self.catalog_total_rows = catalog.catalog_info.total_rows
 
         if self.truth_schema is not None:
-            self.truth_schema = file_io.append_paths_to_pointer(self.truth_schema)
+            self.truth_schema = import_io.append_paths_to_pointer(self.truth_schema)
             if not self.truth_schema.exists():
                 raise FileNotFoundError("truth_schema must be an existing file or directory")


### PR DESCRIPTION
## Change Description

Related to https://github.com/astronomy-commons/lsdb/issues/1249

In debugging the IO operations, I realized these methods are only being used by the import pipelines, and would be better suited to live here (or be replaced by other logic here). After this, the methods can be removed from the `hats` library in a follow-up PR.

## Solution Description


## Code Quality
- [x] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
