### PR TITLE
Fix for new partition info ordering.

### DIFF
--- a/tests/hats_import/catalog/test_run_import.py
+++ b/tests/hats_import/catalog/test_run_import.py
@@ -537,9 +537,9 @@ def test_import_with_existing_pixels(dask_client, small_sky_parts_dir, tmp_path)
     assert catalog.catalog_info.total_rows == 131
     assert catalog.get_healpix_pixels() == [
         HealpixPixel(1, 44),
+        *[HealpixPixel(2, p) for p in range(180, 184)],
         HealpixPixel(1, 46),
         HealpixPixel(1, 47),
-        *[HealpixPixel(2, p) for p in range(180, 184)],
     ]
 
 

--- a/tests/hats_import/catalog/test_run_round_trip.py
+++ b/tests/hats_import/catalog/test_run_round_trip.py
@@ -1014,17 +1014,10 @@ def test_import_gaia_minimum(
     assert len(catalog.get_healpix_pixels()) == 3
 
     # Pick an output file, and make sure it has valid columns:
-    first_pixel = catalog.get_healpix_pixels()[0]
-    output_file = (
-        args.catalog_path
-        / "dataset"
-        / f"Norder={first_pixel.order}"
-        / "Dir=0"
-        / f"Npix={first_pixel.pixel}.parquet"
-    )
+    output_file = args.catalog_path / "dataset" / "Norder=1" / "Dir=0" / "Npix=22.parquet"
     data_frame = pd.read_parquet(output_file)
 
-    # Make sure that the spatial index values match the pixel for the partition (0,5)
+    # Make sure that the spatial index values match the pixel for the partition (0,5) (sub-pixel (1, 22))
     spatial_index_pixels = spatial_index_to_healpix(data_frame["_healpix_29"].values, 0)
     npt.assert_array_equal(spatial_index_pixels, [5, 5, 5])
 


### PR DESCRIPTION
## Change Description

Ordering of HealpixPixels within PartithinInfo changed to use "breadth-first" sorting in https://github.com/astronomy-commons/hats/pull/640

## Code Quality
- [x] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
