### PR TITLE
Rename alignment argument, and shrink alignment, when possible.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-hats @ git+https://github.com/astronomy-commons/hats.git@main
+hats @ git+https://github.com/astronomy-commons/hats.git@issue/529/generate_alignment
 nested-pandas @ git+https://github.com/lincc-frameworks/nested-pandas.git@main

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-hats @ git+https://github.com/astronomy-commons/hats.git@issue/529/generate_alignment
+hats @ git+https://github.com/astronomy-commons/hats.git@main
 nested-pandas @ git+https://github.com/lincc-frameworks/nested-pandas.git@main

--- a/src/hats_import/catalog/resume_plan.py
+++ b/src/hats_import/catalog/resume_plan.py
@@ -69,6 +69,7 @@ class ResumePlan(PipelineResumePlan):
             if import_args.debug_stats_only:
                 run_stages = ["mapping", "finishing"]
             self.input_paths = import_args.input_paths
+            self.mapping_order = import_args.mapping_healpix_order
 
             # Set threshold_mode based on byte_pixel_threshold
             if hasattr(import_args, "byte_pixel_threshold") and import_args.byte_pixel_threshold is not None:
@@ -335,7 +336,7 @@ class ResumePlan(PipelineResumePlan):
         expected_total_rows,
         existing_pixels=None,
         raw_histogram_mem_size=None,
-    ) -> UPath:
+    ) -> tuple[UPath, int]:
         """Get a pointer to the existing alignment file for the pipeline, or
         generate a new alignment using provided arguments.
 
@@ -359,6 +360,7 @@ class ResumePlan(PipelineResumePlan):
             path to cached alignment file.
         """
         file_name = import_io.append_paths_to_pointer(self.tmp_path, self.ALIGNMENT_FILE)
+        self.mapping_order = hp.npix2order(len(raw_histogram))
         if not file_name.exists():
             # If existing_pixels, create an incremental alignment.
             if existing_pixels:
@@ -382,7 +384,8 @@ class ResumePlan(PipelineResumePlan):
                     lowest_order=lowest_healpix_order,
                     threshold=pixel_threshold,
                     drop_empty_siblings=drop_empty_siblings,
-                    mem_size_histogram=raw_histogram_mem_size,
+                    supplemental_count_histogram=raw_histogram_mem_size,
+                    use_lower_order=True,
                 )
 
             # Write alignment to file.
@@ -400,6 +403,7 @@ class ResumePlan(PipelineResumePlan):
                 for (order, pix, row_count) in pixel_list
                 if int(row_count) > 0
             }
+            self.mapping_order = hp.npix2order(len(alignment))
 
         total_rows = sum(self.destination_pixel_map.values())
         if total_rows != expected_total_rows:
@@ -407,7 +411,7 @@ class ResumePlan(PipelineResumePlan):
                 f"Number of rows ({total_rows}) does not match expectation ({expected_total_rows})"
             )
 
-        return file_name
+        return file_name, self.mapping_order
 
     def _generate_constant_healpix_order_alignment(self, raw_histogram_row_count, constant_healpix_order):
         """Generate alignment where all non-empty pixels are at the same healpix order.

--- a/src/hats_import/catalog/resume_plan.py
+++ b/src/hats_import/catalog/resume_plan.py
@@ -69,7 +69,6 @@ class ResumePlan(PipelineResumePlan):
             if import_args.debug_stats_only:
                 run_stages = ["mapping", "finishing"]
             self.input_paths = import_args.input_paths
-            self.mapping_order = import_args.mapping_healpix_order
 
             # Set threshold_mode based on byte_pixel_threshold
             if hasattr(import_args, "byte_pixel_threshold") and import_args.byte_pixel_threshold is not None:
@@ -340,12 +339,16 @@ class ResumePlan(PipelineResumePlan):
         """Get a pointer to the existing alignment file for the pipeline, or
         generate a new alignment using provided arguments.
 
+        NB: The returned alignment may use a lower order than the provided `highest_healpix_order`,
+        if there are NO destination pixels above the returned mapping order.
+
         Args:
             raw_histogram (:obj:`np.array`): one-dimensional numpy array of long integers where the
                 value at each index corresponds to the number of objects found at the healpix pixel.
             constant_healpix_order (int): if positive, use this as the order for
                 all non-empty partitions. else, use remaining arguments.
-            highest_healpix_order (int):  the highest healpix order (e.g. 5-10)
+            highest_healpix_order (int):  the highest healpix order (e.g. 5-10), and often the same
+                order as was used in the `raw_histogram`
             lowest_healpix_order (int): the lowest healpix order (e.g. 1-5). specifying a lowest order
                 constrains the partitioning to prevent spatially large pixels.
             pixel_threshold (int): the maximum number of objects allowed in a single pixel
@@ -357,10 +360,12 @@ class ResumePlan(PipelineResumePlan):
                 found at the healpix pixel. Only required if threshold_mode is 'mem_size'.
 
         Returns:
-            path to cached alignment file.
+            A tuple of (Upath, int), where UPath is the path to the cached alignment file,
+            and int is the mapping_order (the healpix order that should be used when mapping
+            row ra/dec to a healpix bucket).
         """
         file_name = import_io.append_paths_to_pointer(self.tmp_path, self.ALIGNMENT_FILE)
-        self.mapping_order = hp.npix2order(len(raw_histogram))
+        mapping_order = hp.npix2order(len(raw_histogram))
         if not file_name.exists():
             # If existing_pixels, create an incremental alignment.
             if existing_pixels:
@@ -403,7 +408,7 @@ class ResumePlan(PipelineResumePlan):
                 for (order, pix, row_count) in pixel_list
                 if int(row_count) > 0
             }
-            self.mapping_order = hp.npix2order(len(alignment))
+            mapping_order = hp.npix2order(len(alignment))
 
         total_rows = sum(self.destination_pixel_map.values())
         if total_rows != expected_total_rows:
@@ -411,7 +416,7 @@ class ResumePlan(PipelineResumePlan):
                 f"Number of rows ({total_rows}) does not match expectation ({expected_total_rows})"
             )
 
-        return file_name, self.mapping_order
+        return file_name, mapping_order
 
     def _generate_constant_healpix_order_alignment(self, raw_histogram_row_count, constant_healpix_order):
         """Generate alignment where all non-empty pixels are at the same healpix order.

--- a/src/hats_import/catalog/run_import.py
+++ b/src/hats_import/catalog/run_import.py
@@ -77,7 +77,7 @@ def run(args, client):
         threshold = (
             args.pixel_threshold if resume_plan.threshold_mode == "row_count" else args.byte_pixel_threshold
         )
-        alignment_file = resume_plan.get_alignment_file(
+        alignment_file, mapping_order = resume_plan.get_alignment_file(
             raw_histogram_row_count,
             args.constant_healpix_order,
             args.highest_healpix_order,
@@ -99,7 +99,7 @@ def run(args, client):
                     mr.split_pixels,
                     input_file=file_path,
                     pickled_reader_file=pickled_reader_file,
-                    highest_order=args.mapping_healpix_order,
+                    highest_order=mapping_order,
                     ra_column=args.ra_column,
                     dec_column=args.dec_column,
                     splitting_key=key,

--- a/tests/hats_import/catalog/test_file_readers.py
+++ b/tests/hats_import/catalog/test_file_readers.py
@@ -1,10 +1,13 @@
 """Test dataframe-generating file readers"""
 
+import warnings
+
 import numpy as np
 import pandas as pd
 import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
+from astropy.units import UnitsWarning
 from hats.catalog import TableProperties
 
 from hats_import.catalog.file_readers import (
@@ -396,14 +399,18 @@ def test_read_fits_columns(formats_fits):
 
 def test_read_fits_with_nested_columns(formats_fits_nested):
     """Check that nested array data are processed."""
-    table = next(FitsReader().read(formats_fits_nested))
-    assert table["COEFF"].type == pa.list_(pa.float64(), 10)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UnitsWarning)
+        table = next(FitsReader().read(formats_fits_nested))
+        assert table["COEFF"].type == pa.list_(pa.float64(), 10)
 
 
 def test_read_fits_with_nested_tensor_columns(formats_fits_tensor):
     """Check that nested tensor data are processed."""
-    table = next(FitsReader(flatten_tensors=False).read(formats_fits_tensor))
-    assert table["FLUX"].type == pa.fixed_shape_tensor(pa.float32(), (5, 5))
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UnitsWarning)
+        table = next(FitsReader(flatten_tensors=False).read(formats_fits_tensor))
+        assert table["FLUX"].type == pa.fixed_shape_tensor(pa.float32(), (5, 5))
 
-    table = next(FitsReader(flatten_tensors=True).read(formats_fits_tensor))
-    assert table["FLUX"].type == pa.list_(pa.float32(), 25)
+        table = next(FitsReader(flatten_tensors=True).read(formats_fits_tensor))
+        assert table["FLUX"].type == pa.list_(pa.float32(), 25)

--- a/tests/hats_import/catalog/test_map_reduce.py
+++ b/tests/hats_import/catalog/test_map_reduce.py
@@ -385,7 +385,8 @@ def test_split_pixels_headers(formats_headers_csv, assert_parquet_file_ids, tmp_
     plan = ResumePlan(tmp_path=tmp_path, progress_bar=False, input_paths=["foo1"])
     raw_histogram = np.full(12, 0)
     raw_histogram[11] = 131
-    alignment_file = plan.get_alignment_file(raw_histogram, -1, 0, 0, 1_000, False, 131)
+    alignment_file, mapping_order = plan.get_alignment_file(raw_histogram, -1, 0, 0, 1_000, False, 131)
+    assert mapping_order == 0
     mr.split_pixels(
         input_file=formats_headers_csv,
         pickled_reader_file=pickle_file_reader(tmp_path, get_file_reader("csv")),
@@ -411,7 +412,7 @@ def test_split_pixels_single_precision_warning(small_sky_single_file, tmp_path):
     plan = ResumePlan(tmp_path=tmp_path, progress_bar=False, input_paths=["foo1"])
     raw_histogram = np.full(12, 0)
     raw_histogram[11] = 131
-    alignment_file = plan.get_alignment_file(raw_histogram, -1, 0, 0, 1_000, False, 131)
+    alignment_file, _ = plan.get_alignment_file(raw_histogram, -1, 0, 0, 1_000, False, 131)
 
     # Test that the warning is raised when mapping with single-precision ra/dec
     with pytest.warns(UserWarning, match="is not double-precision"):

--- a/tests/hats_import/catalog/test_map_reduce.py
+++ b/tests/hats_import/catalog/test_map_reduce.py
@@ -389,7 +389,7 @@ def test_split_pixels_negative_order(formats_headers_csv, tmp_path):
 
     # Create a fully empty alignment file, which will cause the split_pixels
     # function to attempt to access the unmapped pixel (0, 11).
-    alignment_file = plan.get_alignment_file(np.full(12, 0), -1, 0, 0, 1_000, False, 0)
+    alignment_file, _ = plan.get_alignment_file(np.full(12, 0), -1, 0, 0, 1_000, False, 0)
 
     with pytest.raises(ValueError, match="Data points found in unmapped pixel"):
         mr.split_pixels(

--- a/tests/hats_import/catalog/test_run_round_trip.py
+++ b/tests/hats_import/catalog/test_run_round_trip.py
@@ -1310,7 +1310,7 @@ def test_nested_columns_struct(formats_dir, tmp_path, dask_client):
 
     # The `ParquetPandasReader` returns a pd.DataFrame, converting the
     # column that used to be a list<struct> to struct<list>.
-    output_file = args.catalog_path / "dataset" / "Norder=2" / "Dir=0" / "Npix=0.parquet"
+    output_file = args.catalog_path / "dataset" / "Norder=1" / "Dir=0" / "Npix=0.parquet"
     pixel_data = pq.read_table(output_file)
     assert pa.types.is_struct(pixel_data["lightcurve"].type)
 
@@ -1334,7 +1334,7 @@ def test_nested_columns_struct(formats_dir, tmp_path, dask_client):
 
     # The `ParquetPyarrowReader` does not change the column type.
     # It remains as list<struct>. We confirm when reading it back.
-    output_file = args.catalog_path / "dataset" / "Norder=2" / "Dir=0" / "Npix=0.parquet"
+    output_file = args.catalog_path / "dataset" / "Norder=1" / "Dir=0" / "Npix=0.parquet"
     pixel_data = pq.read_table(output_file)
     col_type = pixel_data.schema.field("lightcurve").type
     assert pa.types.is_list(col_type)

--- a/tests/hats_import/conftest.py
+++ b/tests/hats_import/conftest.py
@@ -51,7 +51,6 @@ def pytest_collection_modifyitems(items):
                 first_dask = False
             item.add_marker(pytest.mark.timeout(timeout))
             item.add_marker(pytest.mark.usefixtures("dask_client"))
-            item.add_marker(pytest.mark.filterwarnings("ignore::DeprecationWarning"))
 
 
 TEST_DIR = os.path.dirname(__file__)


### PR DESCRIPTION
## Change Description

Related to #529 

Implements changes to `generate_alignment` from https://github.com/astronomy-commons/hats/pull/653

I was looking for the warning introduced in the above hats PR, and went on a little side-quest to address other warnings.

## Code Quality
- [x] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [x] My code follows the code style of this project
- [x] My code builds (or compiles) cleanly without any errors or warnings
- [x] My code contains relevant comments and necessary documentation
