### PR TITLE
Catch invalid pixel alignments in split_pixels function to prevent neg vals

### DIFF
--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -257,6 +257,13 @@ def split_pixels(
             for unique_index, pixel_alignment_count in enumerate(unique_pixels):
                 order = pixel_alignment_count[0]
                 pixel = pixel_alignment_count[1]
+                if order < 0 or pixel < 0:
+                    raise ValueError(
+                        f"Invalid pixel alignment found for pixel {pixel} at order {order}. "
+                        "This can be caused by inconsistent dtypes in your spatial columns. "
+                        "Please check that they remain consistent throughout your pipeline "
+                        "to avoid unexpected negative values."
+                    )
                 pixel_dir = get_pixel_cache_directory(cache_shard_path, HealpixPixel(order, pixel))
                 file_io.make_directory(pixel_dir, exist_ok=True)
                 output_file = import_io.append_paths_to_pointer(

--- a/src/hats_import/catalog/map_reduce.py
+++ b/src/hats_import/catalog/map_reduce.py
@@ -259,10 +259,9 @@ def split_pixels(
                 pixel = pixel_alignment_count[1]
                 if order < 0 or pixel < 0:
                     raise ValueError(
-                        f"Invalid pixel alignment found for pixel {pixel} at order {order}. "
-                        "This can be caused by inconsistent dtypes in your spatial columns. "
-                        "Please check that they remain consistent throughout your pipeline "
-                        "to avoid unexpected negative values."
+                        f"Data points found in unmapped pixel (order={order}, pixel={pixel}). "
+                        "This may mean some objects were absent during the mapping phase, or that "
+                        "spatial column dtypes are inconsistent between pipeline stages."
                     )
                 pixel_dir = get_pixel_cache_directory(cache_shard_path, HealpixPixel(order, pixel))
                 file_io.make_directory(pixel_dir, exist_ok=True)

--- a/tests/hats_import/catalog/test_map_reduce.py
+++ b/tests/hats_import/catalog/test_map_reduce.py
@@ -380,6 +380,31 @@ def test_split_pixels_bad_format(blank_data_file, tmp_path, capsys):
     assert "No such file or directory" in captured.out
 
 
+def test_split_pixels_negative_order(formats_headers_csv, tmp_path):
+    """Test raise error when accessing unmapped pixels."""
+
+    plan = ResumePlan(tmp_path=tmp_path, progress_bar=False, input_paths=["foo1"])
+    raw_histogram = np.full(12, 0)
+    raw_histogram[11] = 131
+
+    # Create a fully empty alignment file, which will cause the split_pixels
+    # function to attempt to access the unmapped pixel (0, 11).
+    alignment_file = plan.get_alignment_file(np.full(12, 0), -1, 0, 0, 1_000, False, 0)
+
+    with pytest.raises(ValueError, match="Data points found in unmapped pixel"):
+        mr.split_pixels(
+            input_file=formats_headers_csv,
+            pickled_reader_file=pickle_file_reader(tmp_path, get_file_reader("csv")),
+            highest_order=0,
+            ra_column="ra_mean",
+            dec_column="dec_mean",
+            splitting_key="0",
+            cache_shard_path=tmp_path,
+            resume_path=tmp_path,
+            alignment_file=alignment_file,
+        )
+
+
 def test_split_pixels_headers(formats_headers_csv, assert_parquet_file_ids, tmp_path):
     """Test loading a file with non-default headers"""
     plan = ResumePlan(tmp_path=tmp_path, progress_bar=False, input_paths=["foo1"])


### PR DESCRIPTION
## Change Description
Closes #653