### PR TITLE
Use path helper for thumbnail location.

### DIFF
--- a/tests/hats_import/catalog/test_run_import.py
+++ b/tests/hats_import/catalog/test_run_import.py
@@ -11,6 +11,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from hats import HealpixPixel, read_hats
+from hats.io import paths
 from hats.pixel_math.sparse_histogram import SparseHistogram
 from pyarrow.parquet import ParquetFile
 
@@ -322,7 +323,7 @@ def test_dask_runner(
     assert data_frame.index.dtype == np.int64
 
     # Check that the data thumbnail exists
-    data_thumbnail_pointer = args.catalog_path / "dataset" / "data_thumbnail.parquet"
+    data_thumbnail_pointer = paths.get_data_thumbnail_pointer(args.catalog_path)
     assert data_thumbnail_pointer.exists()
     thumbnail = ParquetFile(data_thumbnail_pointer)
     thumbnail_schema = thumbnail.metadata.schema.to_arrow_schema()


### PR DESCRIPTION
## Change Description

See https://github.com/astronomy-commons/hats/pull/661 and https://github.com/astronomy-commons/hats/issues/630

Changes test check to use the path helper, so this will work with the new location of the `data_thumbnail.parquet` file.

## Solution Description


## Code Quality
- [ ] I have read the [Contribution Guide](https://hats-import.readthedocs.io/en/stable/guide/contributing.html) and [LINCC Frameworks Code of Conduct](https://lsstdiscoveryalliance.org/programs/lincc-frameworks/code-conduct/)
- [ ] My code follows the code style of this project
- [ ] My code builds (or compiles) cleanly without any errors or warnings
- [ ] My code contains relevant comments and necessary documentation
