### PR TITLE
Address smoke test failures.

### DIFF
--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -106,9 +106,7 @@ def run(args: ConversionArguments, client):
         file_io.remove_directory(args.tmp_path, ignore_errors=True)
         step_progress.update(1)
         ## Update total size with newly-written parquet files.
-        properties.__pydantic_extra__["hats_estsize"] = size_estimates.estimate_dir_size(
-            args.catalog_path, divisor=1024
-        )
+        properties.hats_estsize = size_estimates.estimate_dir_size(args.catalog_path, divisor=1024)
         properties.to_properties_file(args.catalog_path)
         partition_info.write_to_file(args.catalog_path / "partition_info.csv")
         step_progress.update(1)

--- a/tests/hats_import/hipscat_conversion/test_run_conversion.py
+++ b/tests/hats_import/hipscat_conversion/test_run_conversion.py
@@ -50,7 +50,7 @@ def test_run_conversion_object(
     assert catalog.on_disk
     assert catalog.catalog_path == args.catalog_path
     assert len(catalog.get_healpix_pixels()) == 1
-    assert int(catalog.catalog_info.__pydantic_extra__["hats_estsize"]) > 0
+    assert catalog.catalog_info.hats_estsize > 0
 
     # Check that the catalog parquet file exists and contains correct object IDs
     output_file = args.catalog_path / "dataset" / "Norder=0" / "Dir=0" / "Npix=11.parquet"
@@ -87,7 +87,7 @@ def test_run_conversion_object(
     assert data.index.name is None
 
     # Check that the data thumbnail exists
-    data_thumbnail_pointer = args.catalog_path / "dataset" / "data_thumbnail.parquet"
+    data_thumbnail_pointer = args.catalog_path / "data_thumbnail.parquet"
     assert data_thumbnail_pointer.exists()
     thumbnail = ParquetFile(data_thumbnail_pointer)
     thumbnail_schema = thumbnail.metadata.schema.to_arrow_schema()
@@ -146,7 +146,7 @@ def test_run_conversion_source(
     assert schema.to_arrow_schema().metadata is None
 
     # Check that the data thumbnail exists
-    data_thumbnail_pointer = args.catalog_path / "dataset" / "data_thumbnail.parquet"
+    data_thumbnail_pointer = args.catalog_path / "data_thumbnail.parquet"
     assert data_thumbnail_pointer.exists()
     thumbnail = ParquetFile(data_thumbnail_pointer)
     thumbnail_schema = thumbnail.metadata.schema.to_arrow_schema()


### PR DESCRIPTION
## Change Description

Address smoke test failures.

## Solution Description

A side effect of a PR yesterday (https://github.com/astronomy-commons/hats-import/pull/698) was the addition of a test stage that installs the FULL dependencies, and runs the full unit test suite. Many tests are skipped because of optional imports, and that included many of the hipscat-conversion tests: these require the `healpy` library to read the older fits files.

Turns out, those tests weren't being run in CI at all, and so existing issues were not being caught:

`hats_estsize` was moved to a proper property of table_properties in https://github.com/astronomy-commons/hats/pull/658 (april 6)

`data_thumbnail.parquet` was moved to the root directory in https://github.com/astronomy-commons/hats/pull/661 (april 29).

Long-term, we should remove the hipscat-conversion pipeline, as nearly all useful catalogs have been converted to HATS.