### PR TITLE
Flush temp FITS file before reading it back by path

### DIFF
--- a/src/hats_import/hipscat_conversion/run_conversion.py
+++ b/src/hats_import/hipscat_conversion/run_conversion.py
@@ -163,6 +163,7 @@ def _write_nested_fits_map(input_dir, output_dir):
         with input_file.open("rb") as _map_file:
             map_data = _map_file.read()
             _tmp_file.write(map_data)
+            _tmp_file.flush()
             map_fits_image = hp.read_map(_tmp_file.name, nest=True, h=True)
             header_dict = dict(map_fits_image[1])
             if header_dict["ORDERING"] != "NESTED":


### PR DESCRIPTION
`_write_nested_fits_map()` wrote the `point_map.fits` bytes into a `NamedTemporaryFile` buffer and then had healpy/astropy open the same path through an independent file descriptor without flushing first. This relied on the buffered writer pushing large single writes straight to the raw file, which held on Python 3.13 (`io.DEFAULT_BUFFER_SIZE == 8192`) but broke on 3.14, where `io.DEFAULT_BUFFER_SIZE` was raised to 131072 (https://github.com/python/cpython/pull/118144), so a 106560-byte fixture now fits entirely in the buffer and stays unflushed on disk. astropy then sees a 0-byte file and raises "OSError: Empty or corrupt FITS file".

Fixes tests/hats_import/hipscat_conversion/test_run_conversion.py::test_run_conversion_source under Python 3.14.